### PR TITLE
Update after ouroboros-network#903

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -62,60 +62,60 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir: iohk-monitoring
-  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
+  tag: 38d601eb3dd20e8a27b7b7008aa90c70db911089
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
+  tag: 38d601eb3dd20e8a27b7b7008aa90c70db911089
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 61a69d7310cc360df788d43814ee40729eaa9340
+  tag: 49fde639a21a13c55795075b5d967bb966f1a923
   subdir: typed-protocols-cbor
 
 --
@@ -125,55 +125,55 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 565df9739781db7589c7220a9125ea46a615dd40
+  tag: ace6b96d8ff13198d938a69c99cb949017c27d18
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 565df9739781db7589c7220a9125ea46a615dd40
+  tag: ace6b96d8ff13198d938a69c99cb949017c27d18
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 565df9739781db7589c7220a9125ea46a615dd40
+  tag: ace6b96d8ff13198d938a69c99cb949017c27d18
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645
+  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645
+  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645
+  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: b7851efb1c2a686c809fe791981bcf8a42fcff41
+  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
+  tag: 4c48d34fd60991bb1b9168d293cfe31a975d858e
   subdir: .
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
+  tag: 4c48d34fd60991bb1b9168d293cfe31a975d858e
   subdir: test
 
 source-repository-package
@@ -184,7 +184,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
-  tag: c0c55abd52058514a3d272e913e6c91dbc951a86
+  tag: 5c4e0b73f209631debd74795fa8cd4c92ed874fb
 
 source-repository-package
   type: git

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "565df9739781db7589c7220a9125ea46a615dd40";
-      sha256 = "1my4zxxn1blp81sqn8vj2cqbv76zllv1scfjlirfivd6x8jl5xnz";
+      rev = "ace6b96d8ff13198d938a69c99cb949017c27d18";
+      sha256 = "10z8s42n66h2af1l5glf4xn62j5xyxcr3iafjmwgld7cijxq47yp";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "565df9739781db7589c7220a9125ea46a615dd40";
-      sha256 = "1my4zxxn1blp81sqn8vj2cqbv76zllv1scfjlirfivd6x8jl5xnz";
+      rev = "ace6b96d8ff13198d938a69c99cb949017c27d18";
+      sha256 = "10z8s42n66h2af1l5glf4xn62j5xyxcr3iafjmwgld7cijxq47yp";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -46,8 +46,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "565df9739781db7589c7220a9125ea46a615dd40";
-      sha256 = "1my4zxxn1blp81sqn8vj2cqbv76zllv1scfjlirfivd6x8jl5xnz";
+      rev = "ace6b96d8ff13198d938a69c99cb949017c27d18";
+      sha256 = "10z8s42n66h2af1l5glf4xn62j5xyxcr3iafjmwgld7cijxq47yp";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645";
-      sha256 = "1jy3f0nba1q71hy8d35kjjz7qcbz6wavv2npkd04xgvfxmgxvd8w";
+      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
+      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645";
-      sha256 = "1jy3f0nba1q71hy8d35kjjz7qcbz6wavv2npkd04xgvfxmgxvd8w";
+      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
+      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645";
-      sha256 = "1jy3f0nba1q71hy8d35kjjz7qcbz6wavv2npkd04xgvfxmgxvd8w";
+      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
+      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -18,7 +18,6 @@
       "library" = {
         depends = [
           (hsPkgs.base)
-          (hsPkgs.aeson)
           (hsPkgs.base58-bytestring)
           (hsPkgs.base64-bytestring-type)
           (hsPkgs.bimap)
@@ -116,8 +115,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645";
-      sha256 = "1jy3f0nba1q71hy8d35kjjz7qcbz6wavv2npkd04xgvfxmgxvd8w";
+      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
+      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "8273fe5f00ac03b0c66ef3841c8e957139ee18f2";
-      sha256 = "0ggfi3jxks5c8k3mszd6k0sfvmbvrkkwimln33r501dzj3m283rs";
+      rev = "4c48d34fd60991bb1b9168d293cfe31a975d858e";
+      sha256 = "104lw3lbm18lphnv24w4j3ykrw8kwc8wf5xqhy39pjvb7sgj89x3";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -69,7 +69,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "8273fe5f00ac03b0c66ef3841c8e957139ee18f2";
-      sha256 = "0ggfi3jxks5c8k3mszd6k0sfvmbvrkkwimln33r501dzj3m283rs";
+      rev = "4c48d34fd60991bb1b9168d293cfe31a975d858e";
+      sha256 = "104lw3lbm18lphnv24w4j3ykrw8kwc8wf5xqhy39pjvb7sgj89x3";
       });
     }

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -2,7 +2,7 @@
   {
     flags = {};
     package = {
-      specVersion = "1.10";
+      specVersion = "2.2";
       identifier = { name = "cardano-shell"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "2018 IOHK";
@@ -35,6 +35,7 @@
           (hsPkgs.QuickCheck)
           (hsPkgs.safe-exceptions)
           (hsPkgs.stm)
+          (hsPkgs.async)
           (hsPkgs.text)
           (hsPkgs.transformers)
           (hsPkgs.generic-monoid)
@@ -46,6 +47,7 @@
             (hsPkgs.base)
             (hsPkgs.cardano-shell)
             (hsPkgs.cardano-prelude)
+            (hsPkgs.pretty-show)
             (hsPkgs.optparse-applicative)
             (hsPkgs.safe-exceptions)
             (hsPkgs.stm)
@@ -59,6 +61,16 @@
             (hsPkgs.cardano-prelude)
             (hsPkgs.optparse-applicative)
             (hsPkgs.safe-exceptions)
+            ];
+          };
+        "daedalus-ipc" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.cardano-shell)
+            (hsPkgs.cardano-prelude)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.safe-exceptions)
+            (hsPkgs.iohk-monitoring)
             ];
           };
         "cardano-launcher" = {
@@ -87,6 +99,7 @@
             (hsPkgs.cardano-prelude)
             (hsPkgs.dhall)
             (hsPkgs.safe-exceptions)
+            (hsPkgs.process)
             (hsPkgs.QuickCheck)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.tree-diff)
@@ -97,13 +110,16 @@
             (hsPkgs.dejafu)
             (hsPkgs.hunit-dejafu)
             ];
+          build-tools = [
+            (hsPkgs.buildPackages.cardano-shell or (pkgs.buildPackages.cardano-shell))
+            ];
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "455c006e5d1a0c1cf3d31777df24752afcbaab10";
-      sha256 = "0y9s5f6fgpqk9qlxgznpddpb6fr42ppkrmpp1kxn7k3dqmydqk7z";
+      rev = "5c4e0b73f209631debd74795fa8cd4c92ed874fb";
+      sha256 = "0202v25kc26fakc1x3xrzrp7bjza0yzpwx12fkdh7a3hsbm4f9hh";
       });
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "contra-tracer"; version = "0.1.0.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bd31cd2f3922010ddb76bb869f29c4e63bb8001b";
-      sha256 = "1dfk505qbpk6p3gcpxa31wmg98qvx9hlrxlf0khaj7hizf3b8b60";
+      rev = "38d601eb3dd20e8a27b7b7008aa90c70db911089";
+      sha256 = "124w5lihspg7vshdk5vyql4g8cpdfx0ijcsvynvkpxadhxw92bar";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "61a69d7310cc360df788d43814ee40729eaa9340";
-      sha256 = "0f2slwaq7yvq1xs3f4nwkzrm0fyn8pnh8qgan353ib2bnj2iy1y6";
+      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
+      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -15,7 +15,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "iohk-monitoring"; version = "0.1.10.0"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "";
       author = "Alexander Diemand, Andreas Triantafyllos";
@@ -36,6 +36,7 @@
           (hsPkgs.async-timer)
           (hsPkgs.attoparsec)
           (hsPkgs.auto-update)
+          (hsPkgs.base64-bytestring)
           (hsPkgs.bytestring)
           (hsPkgs.clock)
           (hsPkgs.containers)
@@ -155,8 +156,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "bd31cd2f3922010ddb76bb869f29c4e63bb8001b";
-      sha256 = "1dfk505qbpk6p3gcpxa31wmg98qvx9hlrxlf0khaj7hizf3b8b60";
+      rev = "38d601eb3dd20e8a27b7b7008aa90c70db911089";
+      sha256 = "124w5lihspg7vshdk5vyql4g8cpdfx0ijcsvynvkpxadhxw92bar";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "61a69d7310cc360df788d43814ee40729eaa9340";
-      sha256 = "0f2slwaq7yvq1xs3f4nwkzrm0fyn8pnh8qgan353ib2bnj2iy1y6";
+      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
+      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -55,6 +55,31 @@
           then [ (hsPkgs.Win32) ]
           else [ (hsPkgs.unix) ]);
         };
+      exes = {
+        "byron-db-converter" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-binary)
+            (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
+            (hsPkgs.directory)
+            (hsPkgs.mtl)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.optparse-generic)
+            (hsPkgs.ouroboros-consensus)
+            (hsPkgs.path)
+            (hsPkgs.path-io)
+            (hsPkgs.reflection)
+            (hsPkgs.resourcet)
+            (hsPkgs.streaming)
+            (hsPkgs.text)
+            (hsPkgs.time)
+            ];
+          };
+        };
       tests = {
         "test-consensus" = {
           depends = [
@@ -121,8 +146,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "61a69d7310cc360df788d43814ee40729eaa9340";
-      sha256 = "0f2slwaq7yvq1xs3f4nwkzrm0fyn8pnh8qgan353ib2bnj2iy1y6";
+      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
+      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -122,8 +122,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "61a69d7310cc360df788d43814ee40729eaa9340";
-      sha256 = "0f2slwaq7yvq1xs3f4nwkzrm0fyn8pnh8qgan353ib2bnj2iy1y6";
+      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
+      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "61a69d7310cc360df788d43814ee40729eaa9340";
-      sha256 = "0f2slwaq7yvq1xs3f4nwkzrm0fyn8pnh8qgan353ib2bnj2iy1y6";
+      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
+      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "61a69d7310cc360df788d43814ee40729eaa9340";
-      sha256 = "0f2slwaq7yvq1xs3f4nwkzrm0fyn8pnh8qgan353ib2bnj2iy1y6";
+      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
+      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/DB.hs
+++ b/src/exec/DB.hs
@@ -35,6 +35,7 @@ import Ouroboros.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Impl as ChainDB
 import Ouroboros.Storage.ChainDB.Impl.Args (ChainDbArgs (..))
+import Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
 import Ouroboros.Storage.ImmutableDB.Types (ValidationPolicy (..))
 import Ouroboros.Storage.LedgerDB.DiskPolicy (DiskPolicy (..))
 import Ouroboros.Storage.LedgerDB.MemPolicy (defaultMemPolicy)
@@ -116,7 +117,7 @@ withDB dbOptions dbTracer indexTracer tr securityParam nodeConfig extLedgerState
         , cdbDiskPolicy = ledgerDiskPolicy
 
         , cdbNodeConfig = nodeConfig
-        , cdbEpochSize = const (pure epochSize)
+        , cdbEpochInfo = fixedSizeEpochInfo epochSize
         , cdbIsEBB = isEBB
         , cdbGenesis = pure extLedgerState
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/8273fe5f00ac03b0c66ef3841c8e957139ee18f2/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4c48d34fd60991bb1b9168d293cfe31a975d858e/snapshot.yaml
 
 packages:
   - .
@@ -6,20 +6,20 @@ packages:
 extra-deps:
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
+    commit: 38d601eb3dd20e8a27b7b7008aa90c70db911089
     subdirs:
       - iohk-monitoring
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 565df9739781db7589c7220a9125ea46a615dd40
+    commit: ace6b96d8ff13198d938a69c99cb949017c27d18
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 7d6cc5d4fd1ce1ca8412b5b68c2ac8fd9b845645
+    commit: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -27,19 +27,19 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
+    commit: 4c48d34fd60991bb1b9168d293cfe31a975d858e
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-shell
-    commit: 455c006e5d1a0c1cf3d31777df24752afcbaab10
+    commit: 5c4e0b73f209631debd74795fa8cd4c92ed874fb
 
   - git: https://github.com/input-output-hk/cardano-sl-x509
     commit: ec96c64c665b741c17b4e38f611315bae9b0b054
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 61a69d7310cc360df788d43814ee40729eaa9340
+    commit: 49fde639a21a13c55795075b5d967bb966f1a923
     subdirs:
       - ouroboros-consensus
       - ouroboros-network
@@ -47,9 +47,6 @@ extra-deps:
       - network-mux
       - typed-protocols
       - typed-protocols-cbor
-
-  - git: https://github.com/well-typed/cborg
-    commit: 992b730ca6fd9c1da191bfecb2b67cabf31b54ad
 
   - git: https://github.com/well-typed/canonical-json
     commit: ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f


### PR DESCRIPTION
This PR also includes #16 until it is merged.

Note that https://github.com/input-output-hk/ouroboros-network/pull/903 hasn't been merged yet. As soon as that is done, this PR can be updated and used to fix the breaking change.

The point of #903 is to trace the progress of the ledger initialisation. Some pointers on how to do this:
* See the new `ChainDB.TraceEvent.TraceLedgerReplayEvent` constructor: https://github.com/input-output-hk/ouroboros-network/pull/903/files#diff-f1834e0128e7b50336516db371f62579R302
* See https://github.com/input-output-hk/ouroboros-network/pull/903/files#diff-1b6e41536e4311c26facb6a658fdb160R388
* The above `TraceReplayEvent` is decorated with more info here: https://github.com/input-output-hk/ouroboros-network/pull/903/files#diff-da0a5a3d801a2f66b948bf6b372a6d82R272
  This includes:
  - The point and epoch of the replayed block
  - The slot of the first block in the epoch of the replayed block. If the block's `pointSlot` equals this slot, it is the first block in the epoch (note that the EBB has the same slot as the first block in the epoch)
  - The point and epoch of the last block that has to be replayed (the tip of the ImmutableDB).
  Using this information, it should be possible to trace  user-friendly progress of the ledger initialisation process. Note that showing progress per epoch might be too slow, progress per 500 blocks/slots or so seems reasonable.

