### PR TITLE
Test the EBBs in the DB against the CDDL spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To run this as a demo you should launch a `byron-proxy` using
 stack exec -- byron-proxy --database-path db-byron-proxy-demo-server \
 \ --index-path index-byron-proxy-demo-server \
 \ --configuration-file ../cardano-sl/lib/configuration.yaml \
-\ --configuration-key mainnet_full --server-host 127.0.0.1 --server-port 7777 \
+\ --configuration-key mainnet_full --local-addr [127.0.0.1]:7777 \
 \ --topology ./topology.yaml
 ```
 , which requires a `cardano-sl` clone in the same directory as your

--- a/cardano-byron-proxy.cabal
+++ b/cardano-byron-proxy.cabal
@@ -131,3 +131,27 @@ executable cardano-byron-proxy
                        -fwarn-unused-imports
                        -Wincomplete-record-updates
                        -Wincomplete-uni-patterns
+
+executable cddl-test
+  main-is:             Main.hs
+  hs-source-dirs:      src/cddl-test
+  default-language:    Haskell2010
+  build-depends:       base,
+                       bytestring,
+                       cardano-byron-proxy,
+                       cardano-crypto-wrapper,
+                       cardano-ledger,
+                       cborg,
+                       contra-tracer,
+                       filepath,
+                       ouroboros-consensus,
+                       process-extras,
+                       reflection
+  ghc-options:         -threaded
+                       -Wall
+                       -Wcompat
+                       -fwarn-redundant-constraints
+                       -fwarn-incomplete-patterns
+                       -fwarn-unused-imports
+                       -Wincomplete-record-updates
+                       -Wincomplete-uni-patterns

--- a/nix/.stack.nix/cardano-byron-proxy.nix
+++ b/nix/.stack.nix/cardano-byron-proxy.nix
@@ -102,6 +102,21 @@
             (hsPkgs.unordered-containers)
             ];
           };
+        "cddl-test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-byron-proxy)
+            (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.cborg)
+            (hsPkgs.contra-tracer)
+            (hsPkgs.filepath)
+            (hsPkgs.ouroboros-consensus)
+            (hsPkgs.process-extras)
+            (hsPkgs.reflection)
+            ];
+          };
         };
       };
     } // rec { src = (pkgs.lib).mkDefault ../.././.; }

--- a/src/cddl-test/Main.hs
+++ b/src/cddl-test/Main.hs
@@ -1,0 +1,120 @@
+-- | A test-function that reads EBB-blocks from a chain DB
+-- and validates the blocks against a CDDL specification of the CBOR encoding.
+-- (CDDL == Concise Data Definition Language)
+-- The test can be run as 'cddl-test CDDLCMD SPECFILE DBPATH'.
+-- CDDLCMD is the path to CDDL cmd.
+-- https://github.com/input-output-hk/cardano-sl/blob/develop/docs/on-the-wire/current-spec.cddl
+-- contains a suitable SPECFILE.
+module Main
+where
+
+import           Prelude hiding ((<>))
+import           System.Environment (getArgs)
+import           System.Exit (ExitCode(..))
+import           System.FilePath ((</>))
+import           System.Process.ByteString.Lazy (readProcessWithExitCode)
+
+import           Control.Exception (throwIO, try)
+import           Data.Word (Word64)
+
+import           Data.Reflection as Reflection (give)
+import           Data.ByteString.Lazy (ByteString)
+import           Data.ByteString.Lazy.Char8 as Char8 (unpack)
+
+import           Control.Tracer (nullTracer)
+import qualified Cardano.Crypto as Cardano (ProtocolMagicId)
+import qualified Cardano.Chain.Slotting as Cardano (EpochSlots (..))
+import           Ouroboros.Consensus.Ledger.Byron.Config (ByronConfig)
+import qualified Ouroboros.Consensus.Ledger.Byron as Byron
+         (decodeByronHeaderHash, encodeByronHeaderHash, encodeByronBlock, decodeByronBlock )
+import           Ouroboros.Byron.Proxy.Block (Block, isEBB)
+
+import           Ouroboros.Storage.Common (EpochSize (..),EpochNo(..))
+import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB, ImmDbArgs(..), openDB, getBlob)
+import           Ouroboros.Storage.FS.API.Types (MountPoint (..))
+import           Ouroboros.Storage.FS.IO (ioHasFS)
+import           Ouroboros.Storage.EpochInfo.Impl (newEpochInfo)
+import           Ouroboros.Storage.ImmutableDB.Types (ImmutableDBError(..), ValidationPolicy(..), UserError (..))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH (exceptions)
+
+-- hard coded values
+epochSize :: Word64
+epochSize = 21600
+epochSlots :: Cardano.EpochSlots
+epochSlots = Cardano.EpochSlots epochSize
+
+givenProtocolMagic :: Cardano.ProtocolMagicId
+givenProtocolMagic = error "protocolMagic"
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        [cddlCmd, spec, dbPath] -> testBlocks cddlCmd spec dbPath Nothing
+        [cddlCmd, spec, dbPath, start, end] -> testBlocks cddlCmd spec dbPath $ Just [startEpoch .. endEpoch]
+            where
+              startEpoch = EpochNo $ read start
+              endEpoch   = EpochNo $ read end
+        _ -> putStrLn  $ concat [
+                "run the tests with :\n"
+               ,"   cddl-test CDDLCMD SPECFILE DBPATH\n"
+               ,"or cddl-test CDDLCMD SPECFILE DBPATH STARTEPOCH ENDEPOCH\n"
+               ]
+
+testBlocks :: FilePath -> FilePath -> FilePath -> Maybe [EpochNo] -> IO ()
+testBlocks cddlCmd cddlSpec chainDBPath range = do
+    db <- give epochSlots $ give givenProtocolMagic (dbArgs chainDBPath >>= openDB)
+    loop db blockList
+    where
+        (isLimitedRange, blockList) = case range of
+            Nothing -> (False , [EpochNo 0 ..])
+            Just r  -> (True  , r)
+
+        loop _ [] = return ()
+        loop db (epoch:rest) = do
+            putStr $ show  epoch
+            block <- readBlock db epoch
+            case block of
+                NoData -> error $ "failed to read ebb block: " ++ show epoch
+                FutureEpoch -> if isLimitedRange
+                    then error $ "ebb block is in the future: " ++ show epoch
+                    else putStrLn "is the future."
+                Block bytes -> do
+                    validateCBOR cddlCmd cddlSpec bytes
+                    putStrLn " OK"
+                    loop db rest
+
+validateCBOR :: FilePath -> FilePath -> ByteString -> IO ()
+validateCBOR cddlCmd cddlSpec bytes = do
+    result <- readProcessWithExitCode cddlCmd [cddlSpec, "validate", "-"] bytes
+    case result of
+        (ExitFailure _, _, err) -> error $ Char8.unpack err
+        (ExitSuccess, _, _) -> return ()
+
+dbArgs :: FilePath -> IO (ImmDbArgs IO (Block ByronConfig))
+dbArgs fp = do
+  epochInfo <- newEpochInfo (const (pure $ EpochSize epochSize))
+  return $ ImmDbArgs {
+      immDecodeHash  = Byron.decodeByronHeaderHash
+    , immDecodeBlock = Byron.decodeByronBlock epochSlots
+    , immEncodeHash  = Byron.encodeByronHeaderHash
+    , immEncodeBlock = Byron.encodeByronBlock
+    , immErr         = EH.exceptions
+    , immEpochInfo   = epochInfo
+    , immValidation  = ValidateMostRecentEpoch
+    , immIsEBB       = isEBB
+    , immHasFS       = ioHasFS $ MountPoint (fp </> "immutable")
+    , immTracer      = nullTracer
+    }
+
+data ReadResult = Block ByteString | FutureEpoch | NoData
+  deriving (Show, Eq)
+
+readBlock :: ImmDB IO (Block ByronConfig) -> EpochNo -> IO ReadResult
+readBlock db epoch = do
+    ret <- try $ give epochSlots $ give givenProtocolMagic $ getBlob db $ Left epoch
+    case ret of
+        (Left (UserError (ReadFutureEBBError _ _) _)) -> return FutureEpoch
+        (Left err) -> throwIO err
+        (Right Nothing) -> return NoData
+        (Right (Just block)) -> return $ Block block


### PR DESCRIPTION
This PR adds a  test-tool that reads EBB-blocks from a chain DB
and validates the blocks against a CDDL specification of the CBOR encoding.
The test can be run as :
``
cddl-test CDDLCMD SPECFILE DBPATH
``
`CDDLCMD` is the path to CDDL command.
A suitable `CDDLSPEC` is here:
https://github.com/input-output-hk/cardano-sl/blob/develop/docs/on-the-wire/current-spec.cddl
