### PR TITLE
pull envs and config from iohkNix.cardanoLib

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,13 +32,7 @@ let
   # nixTools contains all the haskell binaries and libraries built by haskell.nix
   nixTools = import ./nix/nix-tools.nix {};
   # cardano-sl
-  oldCardanoRev = (builtins.fromJSON (builtins.readFile ./nix/old-cardano-sl-src.json)).rev;
-  oldCardanoSrc = import ./nix/old-cardano.nix {
-    inherit commonLib;
-  };
-  oldCardano = (import oldCardanoSrc { gitrev = oldCardanoRev;});
-  inherit (oldCardano) cardanoConfig;
-  environments = builtins.removeAttrs (import (oldCardanoSrc + "/lib.nix")).environments [ "demo" ];
+  inherit (commonLib) cardanoConfig environments;
 
   # scripts contains startup scripts for proxy
   scripts = import ./nix/scripts.nix {

--- a/lib.nix
+++ b/lib.nix
@@ -16,4 +16,4 @@ let
       }) {};
   pkgs = iohkNix.pkgs;
   lib = pkgs.lib;
-in lib // iohkNix
+in lib // iohkNix.cardanoLib // iohkNix

--- a/nix/byron-proxy-scripts.nix
+++ b/nix/byron-proxy-scripts.nix
@@ -24,7 +24,7 @@ let
     } // envConfig
       // customConfig;
   in with config; pkgs.writeScript "byron-proxy-${environment}" ''
-    exec ${byronProxy}/bin/cardano-byron-proxy +RTS -T -RTS --database-path db-byron-proxy-${environment} --index-path index-byron-proxy-${environment} --configuration-file ${configuration}/lib/configuration.yaml --configuration-key ${envConfig.confKey} --topology ${topologyFile} --logger-config ${loggingConfig} --local-addr [${proxyHost}]:${toString proxyPort} ${lib.optionalString (pbftThreshold != null) "--pbft-threshold ${pbftThreshold}"} ${lib.optionalString (nodeId != null) "--node-id ${nodeId}"} $@
+    exec ${byronProxy}/bin/cardano-byron-proxy +RTS -T -RTS --database-path db-byron-proxy-${environment} --index-path index-byron-proxy-${environment} --configuration-file ${configuration}/configuration.yaml --configuration-key ${envConfig.confKey} --topology ${topologyFile} --logger-config ${loggingConfig} --local-addr [${proxyHost}]:${toString proxyPort} ${lib.optionalString (pbftThreshold != null) "--pbft-threshold ${pbftThreshold}"} ${lib.optionalString (nodeId != null) "--node-id ${nodeId}"} $@
   '';
   configuration = cardanoConfig;
 

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "aa26de40d6bb226fade6e3f6e80ef6e0ef70925b",
-  "date": "2019-07-31T11:56:57+00:00",
-  "sha256": "0aqvhm5whr2bzcxbzn69q31i00cdsqqbpay00z69a0vxkv2568rz",
+  "rev": "3ba96c81cd937189e7721973a83d3c12daa506a1",
+  "date": "2019-08-19T17:54:12+00:00",
+  "sha256": "0gxpnk3dzg524zd2k94xqgyaani9fvlam6l7yxs1b2fszd00fk5h",
   "fetchSubmodules": false
 }

--- a/nix/old-cardano-sl-src.json
+++ b/nix/old-cardano-sl-src.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "cdc7bb3bc845ade9920a799da81869daad12f5c0",
-  "sha256": "1hfl4nplnf6rr3knilm3r98anqs8zldfpqgf53smpcf4zbhdcx6s",
-  "fetchSubmodules": false
-}

--- a/nix/old-cardano.nix
+++ b/nix/old-cardano.nix
@@ -1,5 +1,0 @@
-{ commonLib }:
-let
-  pkgs = commonLib.pkgs;
-  cfg = builtins.fromJSON (builtins.readFile ./old-cardano-sl-src.json);
-in pkgs.fetchgit cfg


### PR DESCRIPTION
iohkNix.cardanoLib now contains configuration.yaml and genesis files as well as `environments` and `forEnvironments` so nix no longer needs to depend on cardano-sl (cabal file still does obviously).