### PR TITLE
use latest ouroboros-network

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -73,49 +73,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 49fde639a21a13c55795075b5d967bb966f1a923
+  tag: 912c0639292e95bb72c0985fa06dfae820b01364
   subdir: typed-protocols-cbor
 
 --
@@ -125,43 +125,43 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ace6b96d8ff13198d938a69c99cb949017c27d18
+  tag: 1121579803319f01612583fc445c50b0a0ce0424
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ace6b96d8ff13198d938a69c99cb949017c27d18
+  tag: 1121579803319f01612583fc445c50b0a0ce0424
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ace6b96d8ff13198d938a69c99cb949017c27d18
+  tag: 1121579803319f01612583fc445c50b0a0ce0424
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
+  tag: 70515f1aefdbd60d11061b4b370aa5e54a487e56
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
+  tag: 70515f1aefdbd60d11061b4b370aa5e54a487e56
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
+  tag: 70515f1aefdbd60d11061b4b370aa5e54a487e56
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
+  tag: 70515f1aefdbd60d11061b4b370aa5e54a487e56
   subdir: crypto/test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ace6b96d8ff13198d938a69c99cb949017c27d18";
-      sha256 = "10z8s42n66h2af1l5glf4xn62j5xyxcr3iafjmwgld7cijxq47yp";
+      rev = "1121579803319f01612583fc445c50b0a0ce0424";
+      sha256 = "1yk4sk4id4acz568nx78bcgqpnsnx3hivcd65837j3vajc29rwvq";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ace6b96d8ff13198d938a69c99cb949017c27d18";
-      sha256 = "10z8s42n66h2af1l5glf4xn62j5xyxcr3iafjmwgld7cijxq47yp";
+      rev = "1121579803319f01612583fc445c50b0a0ce0424";
+      sha256 = "1yk4sk4id4acz568nx78bcgqpnsnx3hivcd65837j3vajc29rwvq";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -46,8 +46,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ace6b96d8ff13198d938a69c99cb949017c27d18";
-      sha256 = "10z8s42n66h2af1l5glf4xn62j5xyxcr3iafjmwgld7cijxq47yp";
+      rev = "1121579803319f01612583fc445c50b0a0ce0424";
+      sha256 = "1yk4sk4id4acz568nx78bcgqpnsnx3hivcd65837j3vajc29rwvq";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
-      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
+      rev = "70515f1aefdbd60d11061b4b370aa5e54a487e56";
+      sha256 = "0q6vc0w2d42rynh8x6q6n3cyjpwq4xj277pjjb16ymkr05a6671a";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
-      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
+      rev = "70515f1aefdbd60d11061b4b370aa5e54a487e56";
+      sha256 = "0q6vc0w2d42rynh8x6q6n3cyjpwq4xj277pjjb16ymkr05a6671a";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
-      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
+      rev = "70515f1aefdbd60d11061b4b370aa5e54a487e56";
+      sha256 = "0q6vc0w2d42rynh8x6q6n3cyjpwq4xj277pjjb16ymkr05a6671a";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -28,8 +28,8 @@
           (hsPkgs.cardano-crypto)
           (hsPkgs.cardano-crypto-wrapper)
           (hsPkgs.cardano-prelude)
-          (hsPkgs.cardano-shell)
           (hsPkgs.containers)
+          (hsPkgs.contra-tracer)
           (hsPkgs.concurrency)
           (hsPkgs.cryptonite)
           (hsPkgs.Cabal)
@@ -66,6 +66,7 @@
             (hsPkgs.cardano-prelude)
             (hsPkgs.cardano-prelude-test)
             (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
             (hsPkgs.cryptonite)
             (hsPkgs.cs-blockchain)
             (hsPkgs.cs-ledger)
@@ -98,6 +99,7 @@
             (hsPkgs.cardano-prelude)
             (hsPkgs.cardano-prelude-test)
             (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
             (hsPkgs.directory)
             (hsPkgs.filepath)
             (hsPkgs.formatting)
@@ -115,8 +117,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "0a71b5026bf7bda319e0c50849cf303e036e2f3c";
-      sha256 = "1lh0n1686njzwb0v4vbcqrgiqlsqshg3nfmcsb9zaix0zaicn3da";
+      rev = "70515f1aefdbd60d11061b4b370aa5e54a487e56";
+      sha256 = "0q6vc0w2d42rynh8x6q6n3cyjpwq4xj277pjjb16ymkr05a6671a";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "912c0639292e95bb72c0985fa06dfae820b01364";
+      sha256 = "1qq2lnv5cml5zrm0mwz48wznliclck2pkw5fhm9n9hxrmm469ycq";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "912c0639292e95bb72c0985fa06dfae820b01364";
+      sha256 = "1qq2lnv5cml5zrm0mwz48wznliclck2pkw5fhm9n9hxrmm469ycq";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -26,6 +26,7 @@
           (hsPkgs.contra-tracer)
           (hsPkgs.cardano-ledger-test)
           (hsPkgs.base16-bytestring)
+          (hsPkgs.bifunctors)
           (hsPkgs.bimap)
           (hsPkgs.bytestring)
           (hsPkgs.cardano-binary)
@@ -84,7 +85,11 @@
         "test-consensus" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.cardano-binary)
             (hsPkgs.cardano-crypto-class)
+            (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.cardano-ledger-test)
             (hsPkgs.typed-protocols)
             (hsPkgs.network-mux)
             (hsPkgs.ouroboros-network)
@@ -100,6 +105,7 @@
             (hsPkgs.mtl)
             (hsPkgs.QuickCheck)
             (hsPkgs.random)
+            (hsPkgs.reflection)
             (hsPkgs.serialise)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)
@@ -112,6 +118,8 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.cardano-crypto-class)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.cardano-ledger-test)
             (hsPkgs.ouroboros-network)
             (hsPkgs.ouroboros-network-testing)
             (hsPkgs.ouroboros-consensus)
@@ -131,6 +139,7 @@
             (hsPkgs.QuickCheck)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.random)
+            (hsPkgs.reflection)
             (hsPkgs.serialise)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)
@@ -146,8 +155,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "912c0639292e95bb72c0985fa06dfae820b01364";
+      sha256 = "1qq2lnv5cml5zrm0mwz48wznliclck2pkw5fhm9n9hxrmm469ycq";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -122,8 +122,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "912c0639292e95bb72c0985fa06dfae820b01364";
+      sha256 = "1qq2lnv5cml5zrm0mwz48wznliclck2pkw5fhm9n9hxrmm469ycq";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "912c0639292e95bb72c0985fa06dfae820b01364";
+      sha256 = "1qq2lnv5cml5zrm0mwz48wznliclck2pkw5fhm9n9hxrmm469ycq";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "49fde639a21a13c55795075b5d967bb966f1a923";
-      sha256 = "05hkgsccyawnfh53xskqa3f1pk7g12kcwzf0gwpygyydh42f6bc4";
+      rev = "912c0639292e95bb72c0985fa06dfae820b01364";
+      sha256 = "1qq2lnv5cml5zrm0mwz48wznliclck2pkw5fhm9n9hxrmm469ycq";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/DB.hs
+++ b/src/exec/DB.hs
@@ -27,7 +27,8 @@ import qualified Ouroboros.Consensus.Ledger.Byron as Byron
 import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import Ouroboros.Consensus.Protocol (NodeConfig)
-import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry, forkLinkedTransfer)
+import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry, forkLinked)
+import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry
 import Ouroboros.Storage.FS.API.Types (MountPoint (..))
 import Ouroboros.Storage.FS.IO (ioHasFS)
 import Ouroboros.Storage.Common (EpochSize (..))
@@ -128,5 +129,5 @@ withDB dbOptions dbTracer indexTracer rr securityParam nodeConfig extLedgerState
         }
   bracket (ChainDB.openDB chainDBArgs) ChainDB.closeDB $ \cdb ->
     Sqlite.withIndexAuto epochSlots indexTracer (indexFilePath dbOptions) $ \idx -> do
-      _ <- forkLinkedTransfer rr $ \rr' -> Index.trackChainDB rr' idx cdb
+      _ <- forkLinked rr $ ResourceRegistry.with $ \rr' -> Index.trackChainDB rr' idx cdb
       k idx cdb

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -4,14 +4,10 @@
 
 module Shelley where
 
-import qualified Codec.CBOR.Read as CBOR (DeserialiseFailure)
 import qualified Data.ByteString.Lazy as Lazy
-import qualified Data.Reflection as Reflection (given)
 import Data.Void (Void)
 import Network.Socket (SockAddr)
 
-import Cardano.Binary (fromCBOR, toCBOR)
-import Cardano.Chain.Slotting (EpochSlots)
 -- ToCBOR/FromCBOR UTxOValidationError, for local tx submission codec.
 import Cardano.Chain.UTxO.Validation ()
 import Crypto.Random (drgNew)
@@ -20,28 +16,20 @@ import Ouroboros.Byron.Proxy.Block (Block)
 import Ouroboros.Consensus.Block (BlockProtocol)
 import Ouroboros.Consensus.Protocol (NodeConfig, NodeState)
 import Ouroboros.Consensus.Ledger.Byron (ByronGiven)
-import qualified Ouroboros.Consensus.Ledger.Byron as Byron
 import Ouroboros.Consensus.Ledger.Byron.Config (ByronConfig)
 import Ouroboros.Consensus.Util.Condense (Condense (..))
-import Ouroboros.Consensus.Util.ThreadRegistry (ThreadRegistry)
+import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import Ouroboros.Storage.ChainDB.API (ChainDB)
 
-import Ouroboros.Network.Block (decodePoint, encodePoint)
 import Ouroboros.Network.NodeToNode
 import Ouroboros.Network.Mux
-import Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetch)
-import Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSync)
 import Ouroboros.Network.Protocol.Handshake.Version
-import Ouroboros.Network.Protocol.TxSubmission.Codec (codecTxSubmission)
-import Ouroboros.Network.Protocol.LocalTxSubmission.Codec (codecLocalTxSubmission)
 import Ouroboros.Network.Server.ConnectionTable (ConnectionTable, newConnectionTable)
 import Ouroboros.Consensus.BlockchainTime (BlockchainTime)
 import Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import Ouroboros.Consensus.Node
 import Ouroboros.Consensus.Node.Tracers (nullTracers)
-import Ouroboros.Consensus.Node.Run.Abstract (nodeBlockFetchSize,
-           nodeBlockMatchesHeader, nodeDecodeGenTxId, nodeEncodeGenTxId,
-           nodeDecodeGenTx, nodeEncodeGenTx)
+import Ouroboros.Consensus.Node.Run.Abstract (nodeBlockFetchSize, nodeBlockMatchesHeader)
 import Ouroboros.Consensus.NodeNetwork
 
 newtype Peer = Peer { getPeer :: (SockAddr, SockAddr) }
@@ -60,21 +48,21 @@ type ResponderVersions = Versions NodeToNodeVersion DictVersion (AnyResponderApp
 -- Must have `ByronGiven` because of the constraints on `nodeKernel`
 withShelley
   :: ( ByronGiven )
-  => ThreadRegistry IO
+  => ResourceRegistry IO
   -> ChainDB IO (Block ByronConfig)
   -> NodeConfig (BlockProtocol (Block ByronConfig))
   -> NodeState (BlockProtocol (Block ByronConfig))
   -> BlockchainTime IO
   -> (NodeKernel IO Peer (Block ByronConfig) -> ConnectionTable IO -> InitiatorVersions -> ResponderVersions -> IO t)
   -> IO t
-withShelley tr cdb conf state blockchainTime k = do
+withShelley rr cdb conf state blockchainTime k = do
   ctable <- newConnectionTable
-  let nodeParams = mkParams tr cdb conf state blockchainTime
+  let nodeParams = mkParams rr cdb conf state blockchainTime
   kernel <- nodeKernel nodeParams
   let apps = consensusNetworkApps
         kernel
         nullProtocolTracers
-        codecs
+        (protocolCodecs conf)
         (protocolHandlers nodeParams kernel)
       vs = versions apps
   k kernel ctable (initiatorNetworkApplication <$> vs) (responderNetworkApplication <$> vs)
@@ -88,51 +76,17 @@ versions
   -> Versions NodeToNodeVersion DictVersion (NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ())
 versions = simpleSingletonVersions NodeToNodeV_1 vData (DictVersion nodeToNodeCodecCBORTerm)
 
-codecs
-  :: ( ByronGiven )
-  => ProtocolCodecs (Block ByronConfig) CBOR.DeserialiseFailure IO Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString
-codecs = ProtocolCodecs
-  { pcChainSyncCodec = codecChainSync
-      Byron.encodeByronHeader
-      (Byron.decodeByronHeader epochSlots)
-      (encodePoint Byron.encodeByronHeaderHash)
-      (decodePoint Byron.decodeByronHeaderHash)
-  , pcBlockFetchCodec = codecBlockFetch
-      Byron.encodeByronBlock
-      Byron.encodeByronHeaderHash
-      (Byron.decodeByronBlock epochSlots)
-      Byron.decodeByronHeaderHash
-  , pcTxSubmissionCodec = codecTxSubmission
-      nodeEncodeGenTxId
-      nodeDecodeGenTxId
-      nodeEncodeGenTx
-      nodeDecodeGenTx
-  , pcLocalChainSyncCodec = codecChainSync
-      Byron.encodeByronBlock
-      (Byron.decodeByronBlock epochSlots)
-      (encodePoint Byron.encodeByronHeaderHash)
-      (decodePoint Byron.decodeByronHeaderHash)
-  , pcLocalTxSubmissionCodec = codecLocalTxSubmission
-      nodeEncodeGenTx
-      nodeDecodeGenTx
-      toCBOR
-      fromCBOR
-  }
-  where
-  epochSlots :: EpochSlots
-  epochSlots = Reflection.given
-
 mkParams
   :: ( ByronGiven )
-  => ThreadRegistry IO
+  => ResourceRegistry IO
   -> ChainDB IO (Block ByronConfig)
   -> NodeConfig (BlockProtocol (Block ByronConfig))
   -> NodeState (BlockProtocol (Block ByronConfig))
   -> BlockchainTime IO
   -> NodeParams IO Peer (Block ByronConfig)
-mkParams tr cdb nconf nstate blockchainTime = NodeParams
+mkParams rr cdb nconf nstate blockchainTime = NodeParams
   { tracers = nullTracers
-  , threadRegistry = tr
+  , registry = rr
   , maxClockSkew = ClockSkew 1
   , cfg = nconf
   , initState = nstate

--- a/src/lib/Ouroboros/Byron/Proxy/Block.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Block.hs
@@ -17,7 +17,7 @@ module Ouroboros.Byron.Proxy.Block
   , isEBB
   ) where
 
-import qualified Data.ByteString.Lazy as Lazy
+import qualified Codec.CBOR.Write as CBOR (toStrictByteString)
 
 import qualified Pos.Chain.Block as CSL (HeaderHash)
 import qualified Pos.Crypto.Hashing as Legacy (AbstractHash (..))
@@ -28,7 +28,7 @@ import Cardano.Crypto.Hashing (AbstractHash (..))
 
 import qualified Ouroboros.Consensus.Block as Consensus (GetHeader (..))
 import Ouroboros.Consensus.Ledger.Byron (ByronBlockOrEBB (..),
-         pattern ByronHeaderOrEBB, blockBytes, unByronHeaderOrEBB)
+         pattern ByronHeaderOrEBB, encodeByronBlock, unByronHeaderOrEBB)
 
 -- For type instance HeaderHash (Header blk) = HeaderHash blk
 -- Anyone who imports this module will almost certainly want that instance.
@@ -37,7 +37,7 @@ import Ouroboros.Consensus.Block ()
 type Block cfg = ByronBlockOrEBB cfg
 
 toSerializedBlock :: Block cfg -> SerializedBlock
-toSerializedBlock = Serialized . Lazy.toStrict . blockBytes
+toSerializedBlock = Serialized . CBOR.toStrictByteString . encodeByronBlock
 
 -- TODO: Move these functions to a compatibility module
 coerceHashToLegacy :: Cardano.HeaderHash -> CSL.HeaderHash

--- a/src/lib/Ouroboros/Byron/Proxy/Genesis/Convert.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Genesis/Convert.hs
@@ -20,7 +20,6 @@ import Data.Time.Clock (NominalDiffTime, UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Word (Word16)
 import Numeric.Natural (Natural)
-import System.FilePath ((</>))
 
 import qualified Cardano.Binary as Binary
 import qualified Cardano.Chain.Common as Cardano
@@ -37,13 +36,6 @@ import qualified Pos.Chain.Update as CSL
 import qualified Pos.Core.Common as CSL
 import qualified Pos.Core.Slotting as CSL
 import qualified Pos.Crypto as CSL
-
--- | The `FilePath` will be prefixed to the genesis json filepath, in case of
--- a `GCSrc`.
-convertStaticConfig :: FilePath -> CSL.StaticConfig -> Cardano.StaticConfig
-convertStaticConfig configDir cslConfig = case cslConfig of
-  CSL.GCSrc fp hash -> Cardano.GCSrc (configDir </> fp) (convertHash hash)
-  CSL.GCSpec gspec  -> Cardano.GCSpec (convertGenesisSpec gspec)
 
 convertHash :: CSL.AbstractHash algo a -> Cardano.AbstractHash algo b
 convertHash (CSL.AbstractHash it) = Cardano.AbstractHash it

--- a/src/lib/Ouroboros/Byron/Proxy/Index/ChainDB.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Index/ChainDB.hs
@@ -5,7 +5,6 @@ module Ouroboros.Byron.Proxy.Index.ChainDB
   ( trackChainDB
   ) where
 
-import Control.Concurrent.Async (race)
 import Control.Exception (bracket)
 
 import Ouroboros.Byron.Proxy.Index.Types (Index)

--- a/src/lib/Ouroboros/Byron/Proxy/Index/ChainDB.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Index/ChainDB.hs
@@ -51,8 +51,7 @@ trackReader idx reader = do
     Nothing -> pure ()
 
 -- | Have an Index track a ChainDB using its Reader API. You probably want to
--- race this with some other thread that runs your application. Also
--- remember to forkLinkedTransfer your resource registry.
+-- race this with some other thread that runs your application.
 --
 -- If the ChainDB does not contain the tip of the Index, then the whole index
 -- will be rebuilt.

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,14 +12,14 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: ace6b96d8ff13198d938a69c99cb949017c27d18
+    commit: 1121579803319f01612583fc445c50b0a0ce0424
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 0a71b5026bf7bda319e0c50849cf303e036e2f3c
+    commit: 70515f1aefdbd60d11061b4b370aa5e54a487e56
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -39,7 +39,7 @@ extra-deps:
     commit: ec96c64c665b741c17b4e38f611315bae9b0b054
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 49fde639a21a13c55795075b5d967bb966f1a923
+    commit: 912c0639292e95bb72c0985fa06dfae820b01364
     subdirs:
       - ouroboros-consensus
       - ouroboros-network


### PR DESCRIPTION
Main points:

- `cardano-ledger` was required to update, and it no longer supports the `GCSpec` configuration. No problem: exit if the cardano-sl configuration uses one, telling the user they must use a json genesis file.
- This `ResourceRegistry` is now ubiquitous, and it's tossed me into the pit of failure. I made *one* and used it to make a `ChainDB`, as well as use that `ChainDB`, ~but now the executable dies with `ResourceRegistryUsedFromDifferentThread`~ that was the index not forking a linked one. I fixed that, but uses of `streamBlocks` and `newBlockReader` in the `cardano-sl` logic layer will certainly fail with the same error. Not sure how to proceed. 