### PR TITLE
Update for rewrite of Ledger DB

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -73,49 +73,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
+  tag: 2ad7dced59caece77b6a5e06914aa37d8a3bba23
   subdir: typed-protocols-cbor
 
 --

--- a/cabal.project
+++ b/cabal.project
@@ -73,49 +73,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7a6c4071003bfd3d9829972c21bf43709447c626
+  tag: ff1fb889b80fdd3125bf683faf70d825ff31437c
   subdir: typed-protocols-cbor
 
 --

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "7a6c4071003bfd3d9829972c21bf43709447c626";
-      sha256 = "15bjap25cwpasl2wjzdd35nwfkcznjhvnnpy944lx9dw266hldsk";
+      rev = "ff1fb889b80fdd3125bf683faf70d825ff31437c";
+      sha256 = "1wpgrzvcaigqyhlw80fwg00g1daip8lx08f01d0ki47spb9zwha0";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "7a6c4071003bfd3d9829972c21bf43709447c626";
-      sha256 = "15bjap25cwpasl2wjzdd35nwfkcznjhvnnpy944lx9dw266hldsk";
+      rev = "ff1fb889b80fdd3125bf683faf70d825ff31437c";
+      sha256 = "1wpgrzvcaigqyhlw80fwg00g1daip8lx08f01d0ki47spb9zwha0";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -159,8 +159,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "7a6c4071003bfd3d9829972c21bf43709447c626";
-      sha256 = "15bjap25cwpasl2wjzdd35nwfkcznjhvnnpy944lx9dw266hldsk";
+      rev = "ff1fb889b80fdd3125bf683faf70d825ff31437c";
+      sha256 = "1wpgrzvcaigqyhlw80fwg00g1daip8lx08f01d0ki47spb9zwha0";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -122,8 +122,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "7a6c4071003bfd3d9829972c21bf43709447c626";
-      sha256 = "15bjap25cwpasl2wjzdd35nwfkcznjhvnnpy944lx9dw266hldsk";
+      rev = "ff1fb889b80fdd3125bf683faf70d825ff31437c";
+      sha256 = "1wpgrzvcaigqyhlw80fwg00g1daip8lx08f01d0ki47spb9zwha0";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "7a6c4071003bfd3d9829972c21bf43709447c626";
-      sha256 = "15bjap25cwpasl2wjzdd35nwfkcznjhvnnpy944lx9dw266hldsk";
+      rev = "ff1fb889b80fdd3125bf683faf70d825ff31437c";
+      sha256 = "1wpgrzvcaigqyhlw80fwg00g1daip8lx08f01d0ki47spb9zwha0";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "7a6c4071003bfd3d9829972c21bf43709447c626";
-      sha256 = "15bjap25cwpasl2wjzdd35nwfkcznjhvnnpy944lx9dw266hldsk";
+      rev = "ff1fb889b80fdd3125bf683faf70d825ff31437c";
+      sha256 = "1wpgrzvcaigqyhlw80fwg00g1daip8lx08f01d0ki47spb9zwha0";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/DB.hs
+++ b/src/exec/DB.hs
@@ -40,7 +40,7 @@ import           Ouroboros.Storage.FS.API.Types            (MountPoint (..))
 import           Ouroboros.Storage.FS.IO                   (ioHasFS)
 import           Ouroboros.Storage.ImmutableDB.Types       (ValidationPolicy (..))
 import           Ouroboros.Storage.LedgerDB.DiskPolicy     (DiskPolicy (..))
-import           Ouroboros.Storage.LedgerDB.MemPolicy      (defaultMemPolicy)
+import           Ouroboros.Storage.LedgerDB.InMemory       (ledgerDbDefaultParams)
 import qualified Ouroboros.Storage.Util.ErrorHandling      as EH
 
 data DBConfig = DBConfig
@@ -115,7 +115,7 @@ withDB dbOptions dbTracer indexTracer rr nodeConfig extLedgerState k = do
 
         , cdbValidation = ValidateMostRecentEpoch
         , cdbBlocksPerFile = 21600 -- ?
-        , cdbMemPolicy = defaultMemPolicy (protocolSecurityParam nodeConfig)
+        , cdbParamsLgrDB = ledgerDbDefaultParams (protocolSecurityParam nodeConfig)
         , cdbDiskPolicy = ledgerDiskPolicy
 
         , cdbNodeConfig = nodeConfig

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -322,6 +322,7 @@ runShelleyServer
 runShelleyServer addr _ ctable rversions = do
   addrInfo <- resolveAddress addr
   withServer
+    nullTracer
     ctable
     addrInfo
     Shelley.mkPeer

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -45,7 +45,7 @@ mkPeer a b = Peer (a, b)
 
 type InitiatorVersions = Versions NodeToNodeVersion DictVersion (OuroborosApplication 'InitiatorApp Peer NodeToNodeProtocols IO Lazy.ByteString () Void)
 
-type ResponderVersions = Versions NodeToNodeVersion DictVersion (AnyResponderApp Peer NodeToNodeProtocols IO Lazy.ByteString)
+type ResponderVersions = Versions NodeToNodeVersion DictVersion (OuroborosApplication 'ResponderApp Peer NodeToNodeProtocols IO Lazy.ByteString Void ())
 
 -- Must have `ByronGiven` because of the constraints on `nodeKernel`
 withShelley

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ extra-deps:
     commit: ec96c64c665b741c17b4e38f611315bae9b0b054
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 7a6c4071003bfd3d9829972c21bf43709447c626
+    commit: ff1fb889b80fdd3125bf683faf70d825ff31437c
     subdirs:
       - ouroboros-consensus
       - ouroboros-network


### PR DESCRIPTION
This updates the Byron proxy for the rewrite of the Ledger DB in-memory representation (https://github.com/input-output-hk/ouroboros-network/pull/1021). Note however that the Byron proxy does not currently build against the latest `ouroboros-network` repo master:

```
src/exec/Shelley.hs:48:66: error:
    Not in scope: type constructor or class 'AnyResponderApp'
   |
48 | type ResponderVersions = Versions NodeToNodeVersion DictVersion (AnyResponderApp Peer NodeToNodeProtocols IO Lazy.ByteString)
   |                                                                  ^^^^^^^^^^^^^^^
cabal: Failed to build exe:cardano-byron-proxy from
cardano-byron-proxy-0.1.0.0.
```

Not sure where that is coming from.

Draft PR because we should also update the hash (I tested with a local branch that rebases my Ledger DB patch against the version of `ouroboros-network` that the proxy currently builds against).