### PR TITLE
Update for latest consensus

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,49 +74,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 95ed390f366f34b4a20a52445d7c21e0a1a02a6
+  tag: 797dd912a3ac99179569ced2e010968306c51483
   subdir: typed-protocols-cbor
 
 --

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { checktvarinvariant = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "io-sim-classes"; version = "0.1.0.0"; };
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "95ed390f366f34b4a20a52445d7c21e0a1a02a66";
-      sha256 = "06glb1vk8hv5cwbbwkj1kv9b41fwk2z8psg28qgidsq1c28ngihw";
+      rev = "797dd912a3ac99179569ced2e010968306c51483";
+      sha256 = "0c7dgr41fn0pj8c9r9d7c3vbpilr1bg34r45m7519w968q0i7m9s";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "95ed390f366f34b4a20a52445d7c21e0a1a02a66";
-      sha256 = "06glb1vk8hv5cwbbwkj1kv9b41fwk2z8psg28qgidsq1c28ngihw";
+      rev = "797dd912a3ac99179569ced2e010968306c51483";
+      sha256 = "0c7dgr41fn0pj8c9r9d7c3vbpilr1bg34r45m7519w968q0i7m9s";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -159,8 +159,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "95ed390f366f34b4a20a52445d7c21e0a1a02a66";
-      sha256 = "06glb1vk8hv5cwbbwkj1kv9b41fwk2z8psg28qgidsq1c28ngihw";
+      rev = "797dd912a3ac99179569ced2e010968306c51483";
+      sha256 = "0c7dgr41fn0pj8c9r9d7c3vbpilr1bg34r45m7519w968q0i7m9s";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -107,11 +107,18 @@
             (hsPkgs.cardano-binary)
             (hsPkgs.cborg)
             (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
             (hsPkgs.fingertree)
             (hsPkgs.hashable)
+            (hsPkgs.io-sim)
             (hsPkgs.io-sim-classes)
+            (hsPkgs.network-mux)
+            (hsPkgs.pipes)
             (hsPkgs.process-extras)
+            (hsPkgs.QuickCheck)
             (hsPkgs.serialise)
+            (hsPkgs.tasty)
+            (hsPkgs.tasty-quickcheck)
             (hsPkgs.text)
             (hsPkgs.typed-protocols-cbor)
             (hsPkgs.typed-protocols)
@@ -122,8 +129,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "95ed390f366f34b4a20a52445d7c21e0a1a02a66";
-      sha256 = "06glb1vk8hv5cwbbwkj1kv9b41fwk2z8psg28qgidsq1c28ngihw";
+      rev = "797dd912a3ac99179569ced2e010968306c51483";
+      sha256 = "0c7dgr41fn0pj8c9r9d7c3vbpilr1bg34r45m7519w968q0i7m9s";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "95ed390f366f34b4a20a52445d7c21e0a1a02a66";
-      sha256 = "06glb1vk8hv5cwbbwkj1kv9b41fwk2z8psg28qgidsq1c28ngihw";
+      rev = "797dd912a3ac99179569ced2e010968306c51483";
+      sha256 = "0c7dgr41fn0pj8c9r9d7c3vbpilr1bg34r45m7519w968q0i7m9s";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "95ed390f366f34b4a20a52445d7c21e0a1a02a66";
-      sha256 = "06glb1vk8hv5cwbbwkj1kv9b41fwk2z8psg28qgidsq1c28ngihw";
+      rev = "797dd912a3ac99179569ced2e010968306c51483";
+      sha256 = "0c7dgr41fn0pj8c9r9d7c3vbpilr1bg34r45m7519w968q0i7m9s";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/Byron.hs
+++ b/src/exec/Byron.hs
@@ -38,7 +38,7 @@ import Ouroboros.Byron.Proxy.Block (Block, ByronBlockOrEBB (..),
          coerceHashToLegacy, unByronHeaderOrEBB, headerHash)
 import Ouroboros.Byron.Proxy.Main
 import Ouroboros.Consensus.Block (Header)
-import Ouroboros.Consensus.Ledger.Byron (ByronGiven)
+import Ouroboros.Consensus.Ledger.Byron (ByronGiven, ByronHash(..))
 import Ouroboros.Consensus.Protocol.Abstract (SecurityParam (maxRollbacks))
 import Ouroboros.Network.Block (ChainHash (..), Point, pointHash)
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -138,8 +138,8 @@ download tracer genesisBlock epochSlots securityParam db bp = do
 
   pointToHash :: Point (Header (Block cfg)) -> Maybe CSL.HeaderHash
   pointToHash pnt = case pointHash pnt of
-    GenesisHash    -> Nothing
-    BlockHash hash -> Just $ coerceHashToLegacy hash
+    GenesisHash                -> Nothing
+    BlockHash (ByronHash hash) -> Just $ coerceHashToLegacy hash
 
   -- Offsets for selectPoints. Defined in the same way as for the Shelley
   -- chain sync client: fibonacci numbers including 0 and k.

--- a/src/lib/Ouroboros/Byron/Proxy/Block.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Block.hs
@@ -32,7 +32,7 @@ import qualified Cardano.Chain.Block as Cardano
 import Cardano.Crypto.Hashing (AbstractHash (..))
 
 import qualified Ouroboros.Consensus.Block as Consensus (GetHeader (..))
-import Ouroboros.Consensus.Ledger.Byron (ByronBlockOrEBB (..),
+import Ouroboros.Consensus.Ledger.Byron (ByronBlockOrEBB (..), ByronHash(..),
          pattern ByronHeaderOrEBB, encodeByronBlock, unByronHeaderOrEBB)
 
 -- For type instance HeaderHash (Header blk) = HeaderHash blk
@@ -55,8 +55,8 @@ coerceHashToLegacy (AbstractHash digest) = Legacy.AbstractHash digest
 
 -- | Convert from a legacy header hash to a new header hash. They are
 -- structurally the same, nominally different.
-coerceHashFromLegacy :: CSL.HeaderHash -> Cardano.HeaderHash
-coerceHashFromLegacy (Legacy.AbstractHash digest) = AbstractHash digest
+coerceHashFromLegacy :: CSL.HeaderHash -> ByronHash
+coerceHashFromLegacy (Legacy.AbstractHash digest) = ByronHash $ AbstractHash digest
 
 -- | Same a `blockHash` but doesn't need `ByronGiven`.
 headerHash :: Consensus.Header (Block cfg) -> Cardano.HeaderHash
@@ -66,7 +66,7 @@ headerHash hdr = case unByronHeaderOrEBB hdr of
 
 -- | Gives `Just` with the block's header's hash, whenever it's an epoch
 -- boundary block.
-isEBB :: Block cfg -> Maybe Cardano.HeaderHash
+isEBB :: Block cfg -> Maybe ByronHash
 isEBB blk = case unByronBlockOrEBB blk of
   Cardano.ABOBBlock    _ -> Nothing
-  Cardano.ABOBBoundary _ -> Just $ headerHash (Consensus.getHeader blk)
+  Cardano.ABOBBoundary _ -> Just $ ByronHash $ headerHash (Consensus.getHeader blk)

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 95ed390f366f34b4a20a52445d7c21e0a1a02a66
+    commit: 797dd912a3ac99179569ced2e010968306c51483
     subdirs:
       - ouroboros-consensus
       - ouroboros-network


### PR DESCRIPTION
Which contains a memory leak fix
(https://github.com/input-output-hk/ouroboros-network/pull/1048).

Most of the changes here are to deal with the fact that Byron instance for consensus now wraps header hashes in a newtype.