### PR TITLE
Update for latest ouroboros-network

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,49 +74,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
   subdir: typed-protocols-cbor
 
 --
@@ -126,55 +126,55 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 025792e51aea9c0078bdb595f8715ad3baf2b97a
+  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 025792e51aea9c0078bdb595f8715ad3baf2b97a
+  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 025792e51aea9c0078bdb595f8715ad3baf2b97a
+  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 025792e51aea9c0078bdb595f8715ad3baf2b97a
+  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 96e8dcb29dc3c29eee99c0d020152fad6071af6d
+  tag: b9bf62f2bab90539809bee13620fe7d29b35928d
   subdir: .
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 96e8dcb29dc3c29eee99c0d020152fad6071af6d
+  tag: b9bf62f2bab90539809bee13620fe7d29b35928d
   subdir: test
 
 source-repository-package

--- a/cardano-byron-proxy.cabal
+++ b/cardano-byron-proxy.cabal
@@ -88,6 +88,7 @@ executable cardano-byron-proxy
                        cardano-binary,
                        cardano-crypto-wrapper,
                        cardano-ledger,
+                       cardano-prelude,
                        cardano-sl,
                        cardano-sl-binary,
                        cardano-sl-chain,

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ccbc085f1ebdde706feb7955fdebb33260dc5e32";
-      sha256 = "0c6qrpch9pc8sir89ddrr1hllm1yksviyw9d4m46x7xbqsby9dcv";
+      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
+      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ccbc085f1ebdde706feb7955fdebb33260dc5e32";
-      sha256 = "0c6qrpch9pc8sir89ddrr1hllm1yksviyw9d4m46x7xbqsby9dcv";
+      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
+      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-byron-proxy.nix
+++ b/nix/.stack.nix/cardano-byron-proxy.nix
@@ -69,6 +69,7 @@
             (hsPkgs.cardano-binary)
             (hsPkgs.cardano-crypto-wrapper)
             (hsPkgs.cardano-ledger)
+            (hsPkgs.cardano-prelude)
             (hsPkgs.cardano-sl)
             (hsPkgs.cardano-sl-binary)
             (hsPkgs.cardano-sl-chain)

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -23,6 +23,7 @@
           (hsPkgs.cardano-binary)
           (hsPkgs.cardano-prelude)
           (hsPkgs.cryptonite)
+          (hsPkgs.deepseq)
           (hsPkgs.memory)
           (hsPkgs.reflection)
           (hsPkgs.vector)
@@ -47,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ccbc085f1ebdde706feb7955fdebb33260dc5e32";
-      sha256 = "0c6qrpch9pc8sir89ddrr1hllm1yksviyw9d4m46x7xbqsby9dcv";
+      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
+      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "025792e51aea9c0078bdb595f8715ad3baf2b97a";
-      sha256 = "07yj6xipxxan60aalwgkgnivmnc84mwywrilcfh758fg82xr220d";
+      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
+      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "025792e51aea9c0078bdb595f8715ad3baf2b97a";
-      sha256 = "07yj6xipxxan60aalwgkgnivmnc84mwywrilcfh758fg82xr220d";
+      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
+      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "025792e51aea9c0078bdb595f8715ad3baf2b97a";
-      sha256 = "07yj6xipxxan60aalwgkgnivmnc84mwywrilcfh758fg82xr220d";
+      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
+      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -117,8 +117,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "025792e51aea9c0078bdb595f8715ad3baf2b97a";
-      sha256 = "07yj6xipxxan60aalwgkgnivmnc84mwywrilcfh758fg82xr220d";
+      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
+      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "96e8dcb29dc3c29eee99c0d020152fad6071af6d";
-      sha256 = "1ayb5h048qmwvmgzm4ckzg7x8pcscd8znlhrj0438vv8wbvx77rl";
+      rev = "b9bf62f2bab90539809bee13620fe7d29b35928d";
+      sha256 = "0fzk6z3dgnz5wrj7zp3gxzrf11hcik22ibp5z4i8d7d7hg0ngs9h";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -71,7 +71,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "96e8dcb29dc3c29eee99c0d020152fad6071af6d";
-      sha256 = "1ayb5h048qmwvmgzm4ckzg7x8pcscd8znlhrj0438vv8wbvx77rl";
+      rev = "b9bf62f2bab90539809bee13620fe7d29b35928d";
+      sha256 = "0fzk6z3dgnz5wrj7zp3gxzrf11hcik22ibp5z4i8d7d7hg0ngs9h";
       });
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739";
-      sha256 = "0m80nqyg5rf7y8q7dnvdlpgs0k67dfjgi9kwqxidkr5k0f6jr50n";
+      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
+      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739";
-      sha256 = "0m80nqyg5rf7y8q7dnvdlpgs0k67dfjgi9kwqxidkr5k0f6jr50n";
+      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
+      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { checktvarinvariant = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "ouroboros-consensus"; version = "0.1.0.0"; };
@@ -25,7 +25,6 @@
           (hsPkgs.io-sim-classes)
           (hsPkgs.contra-tracer)
           (hsPkgs.cardano-ledger-test)
-          (hsPkgs.base16-bytestring)
           (hsPkgs.bifunctors)
           (hsPkgs.bimap)
           (hsPkgs.bytestring)
@@ -88,6 +87,8 @@
         "test-consensus" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.base16-bytestring)
+            (hsPkgs.bytestring)
             (hsPkgs.cardano-binary)
             (hsPkgs.cardano-crypto-class)
             (hsPkgs.cardano-crypto-wrapper)
@@ -103,6 +104,7 @@
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
             (hsPkgs.cryptonite)
+            (hsPkgs.deepseq)
             (hsPkgs.fgl)
             (hsPkgs.fingertree)
             (hsPkgs.generics-sop)
@@ -133,12 +135,14 @@
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.io-sim-classes)
             (hsPkgs.io-sim)
+            (hsPkgs.base16-bytestring)
             (hsPkgs.bifunctors)
             (hsPkgs.binary)
             (hsPkgs.bytestring)
             (hsPkgs.cereal)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
+            (hsPkgs.deepseq)
             (hsPkgs.directory)
             (hsPkgs.fingertree)
             (hsPkgs.generics-sop)
@@ -164,8 +168,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739";
-      sha256 = "0m80nqyg5rf7y8q7dnvdlpgs0k67dfjgi9kwqxidkr5k0f6jr50n";
+      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
+      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -132,8 +132,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739";
-      sha256 = "0m80nqyg5rf7y8q7dnvdlpgs0k67dfjgi9kwqxidkr5k0f6jr50n";
+      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
+      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739";
-      sha256 = "0m80nqyg5rf7y8q7dnvdlpgs0k67dfjgi9kwqxidkr5k0f6jr50n";
+      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
+      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739";
-      sha256 = "0m80nqyg5rf7y8q7dnvdlpgs0k67dfjgi9kwqxidkr5k0f6jr50n";
+      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
+      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module Shelley where
@@ -12,6 +12,8 @@ import Network.Socket (SockAddr)
 import Cardano.Chain.UTxO.Validation ()
 import Crypto.Random (drgNew)
 import qualified Network.Socket as Socket
+
+import Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF(..))
 
 import Ouroboros.Byron.Proxy.Block (Block)
 import Ouroboros.Consensus.Block (BlockProtocol)
@@ -37,6 +39,7 @@ import Ouroboros.Consensus.NodeNetwork
 
 newtype Peer = Peer { getPeer :: (SockAddr, SockAddr) }
   deriving (Eq, Ord, Show)
+  deriving NoUnexpectedThunks via OnlyCheckIsWHNF "Peer" Peer
 
 instance Condense Peer where
   condense = show

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,14 +12,14 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+    commit: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 025792e51aea9c0078bdb595f8715ad3baf2b97a
+    commit: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -27,7 +27,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 96e8dcb29dc3c29eee99c0d020152fad6071af6d
+    commit: b9bf62f2bab90539809bee13620fe7d29b35928d
     subdirs:
       - .
       - test
@@ -41,7 +41,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: e7a13e34d45f17e4d03a2c96a9c3469e0c6f2739
+    commit: fc6a38f6d7cdfce53fad2c30870ff33b32633276
     subdirs:
       - ouroboros-consensus
       - ouroboros-network


### PR DESCRIPTION
Depends on https://github.com/input-output-hk/ouroboros-network/pull/1114 .

Should probably use the cardano repo tool to check it's using the latest dependencies of everything; I just wanted to check if I could make it work with latest consensus.