### PR TITLE
bump ouroboros-network, cardano-ledger revisions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,49 +74,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
   subdir: typed-protocols-cbor
 
 --
@@ -144,25 +144,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
+  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
+  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
+  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
+  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
   subdir: crypto/test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
-      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
+      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
+      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
-      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
+      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
+      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
-      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
+      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
+      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -117,8 +117,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3";
-      sha256 = "1k09p7fa98k2n2ywsz0vikw4y8qnr1ncai4sxhs3f5ifwrrhga59";
+      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
+      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
-      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
+      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
+      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -62,8 +62,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
-      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
+      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
+      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -168,8 +168,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
-      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
+      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
+      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -132,8 +132,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
-      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
+      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
+      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
-      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
+      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
+      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "fc6a38f6d7cdfce53fad2c30870ff33b32633276";
-      sha256 = "0vzcjyy7cq2ld6p9fyxyxmgcr8hy1snc5rp5m7dahk9sfxyb3x3q";
+      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
+      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -25,6 +25,7 @@ import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import Ouroboros.Storage.ChainDB.API (ChainDB)
 
 import Ouroboros.Network.NodeToNode
+import Ouroboros.Network.Magic (NetworkMagic (..))
 import Ouroboros.Network.Mux
 import Ouroboros.Network.Protocol.ChainSync.PipelineDecision (pipelineDecisionLowHighMark)
 import Ouroboros.Network.Protocol.Handshake.Version
@@ -75,7 +76,7 @@ withShelley rr cdb conf state blockchainTime k = do
 
 -- | Found in cardano-node that the network magic should be 0.
 vData :: NodeToNodeVersionData
-vData = NodeToNodeVersionData { networkMagic = 0 }
+vData = NodeToNodeVersionData { networkMagic = NetworkMagic 0 }
 
 versions
   :: NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ()

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -20,6 +20,7 @@ import Ouroboros.Consensus.Block (BlockProtocol)
 import Ouroboros.Consensus.Protocol (NodeConfig, NodeState)
 import Ouroboros.Consensus.Ledger.Byron (ByronGiven)
 import Ouroboros.Consensus.Ledger.Byron.Config (ByronConfig)
+import Ouroboros.Consensus.Mempool.Impl (MempoolCapacity (..))
 import Ouroboros.Consensus.Util.Condense (Condense (..))
 import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import Ouroboros.Storage.ChainDB.API (ChainDB)
@@ -107,4 +108,5 @@ mkParams rr cdb nconf nstate blockchainTime = NodeArgs
   , blockMatchesHeader = nodeBlockMatchesHeader
   , maxUnackTxs = maxBound
   , chainSyncPipelining = pipelineDecisionLowHighMark 200 300 -- TODO: make configurable!
+  , mempoolCap = MempoolCapacity 2048 -- TODO: is this value ok?
   }

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -104,5 +104,6 @@ mkParams rr cdb nconf nstate blockchainTime = NodeArgs
   , blockMatchesHeader = nodeBlockMatchesHeader
   , maxUnackTxs = maxBound
   , chainSyncPipelining = pipelineDecisionLowHighMark 200 300 -- TODO: make configurable!
-  , mempoolCap = MempoolCapacity 2048 -- TODO: is this value ok?
+  -- Mempool capacity limited to 200, sourced from the legacy cardano-sl config
+  , mempoolCap = MempoolCapacity 200
   }

--- a/src/lib/Ouroboros/Byron/Proxy/Genesis/Convert.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Genesis/Convert.hs
@@ -24,7 +24,7 @@ import Numeric.Natural (Natural)
 import qualified Cardano.Binary as Binary
 import qualified Cardano.Chain.Common as Cardano
 import qualified Cardano.Chain.Delegation as Cardano
-import qualified Cardano.Chain.Delegation (signature)
+import qualified Cardano.Chain.Delegation (annotation, signature)
 import qualified Cardano.Chain.Genesis as Cardano
 import qualified Cardano.Chain.Slotting as Cardano
 import qualified Cardano.Chain.Update as Cardano
@@ -87,6 +87,7 @@ convertProxySKHeavy psk = Cardano.UnsafeACertificate
   , Cardano.issuerVK = convertPublicKey (CSL.pskIssuerPk psk)
   , Cardano.delegateVK = convertPublicKey (CSL.pskDelegatePk psk)
   , Cardano.Chain.Delegation.signature = convertCert (CSL.pskCert psk)
+  , Cardano.Chain.Delegation.annotation = ()
   }
 
 convertHeavyDlgIndex :: CSL.HeavyDlgIndex -> Binary.Annotated Cardano.EpochNumber ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: edfbc26b34faae0d1f3e007a3ae21dd9716ca8f3
+    commit: a1de5b52c32255464564a6c5a8a9e474086e3875
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -41,7 +41,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: fc6a38f6d7cdfce53fad2c30870ff33b32633276
+    commit: d3e71facd53da4a2c72e4947f551ddeac45fba41
     subdirs:
       - ouroboros-consensus
       - ouroboros-network


### PR DESCRIPTION
Most significant change is to the transaction relay part. Only money transactions are relayed. This is implemented by filtering out the mempool items that are not money transactions, and otherwise doing exactly what was done before.