### PR TITLE
Bump deps and update to changes in them

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,49 +74,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+  tag: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
   subdir: typed-protocols-cbor
 
 --

--- a/cabal.project
+++ b/cabal.project
@@ -74,49 +74,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d3e71facd53da4a2c72e4947f551ddeac45fba41
+  tag: b7d3ef6c68169e5ce4396b26085a9cebc500f615
   subdir: typed-protocols-cbor
 
 --
@@ -126,55 +126,55 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
+  tag: 5c575d46afbfe333de0ccba70b084db8302abf42
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
+  tag: 5c575d46afbfe333de0ccba70b084db8302abf42
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
+  tag: 5c575d46afbfe333de0ccba70b084db8302abf42
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
+  tag: 181f69af290412abecefc07e1b26e77a453755ff
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
+  tag: 181f69af290412abecefc07e1b26e77a453755ff
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
+  tag: 181f69af290412abecefc07e1b26e77a453755ff
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: a1de5b52c32255464564a6c5a8a9e474086e3875
+  tag: 181f69af290412abecefc07e1b26e77a453755ff
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: b9bf62f2bab90539809bee13620fe7d29b35928d
+  tag: ad19158c7599bc5d50fe7cb0111a1488a139a381
   subdir: .
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: b9bf62f2bab90539809bee13620fe7d29b35928d
+  tag: ad19158c7599bc5d50fe7cb0111a1488a139a381
   subdir: test
 
 source-repository-package
@@ -186,7 +186,7 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
   subdir: cardano-shell
-  tag: 8b8437fa2c0cd7e0c1f0ee94ae1565dbcf5617d0
+  tag: 8abae427c44f0b447117f78e2c1f5006dac2edf8
 
 source-repository-package
   type: git
@@ -196,97 +196,97 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: lib
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: util
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: util/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: infra/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: core
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: core/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: chain
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: chain/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: db/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 95c03f565e6f1ab1b863bcfb13638333851e6c75
+  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
   subdir: networking
 
 source-repository-package

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,33 +52,35 @@
       synopsis = "Test helpers from cardano-binary exposed to other packages";
       description = "Test helpers from cardano-binary exposed to other packages";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cardano-prelude-test)
-          (hsPkgs.cborg)
-          (hsPkgs.containers)
-          (hsPkgs.formatting)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.pretty-show)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.text)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
-      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
+      rev = "5c575d46afbfe333de0ccba70b084db8302abf42";
+      sha256 = "1v1q20fjb6klcdhl9mhpvd10j6vc7biwk91dgyfp6ld7xvj2703x";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-byron-proxy.nix
+++ b/nix/.stack.nix/cardano-byron-proxy.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,110 +52,114 @@
       synopsis = "Adapter for the Byron net";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.async)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-crypto-wrapper)
-          (hsPkgs.cardano-ledger)
-          (hsPkgs.cardano-sl)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-db)
-          (hsPkgs.cardano-sl-infra)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cborg)
-          (hsPkgs.conduit)
-          (hsPkgs.containers)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.cryptonite)
-          (hsPkgs.directory)
-          (hsPkgs.filepath)
-          (hsPkgs.io-sim-classes)
-          (hsPkgs.iohk-monitoring)
-          (hsPkgs.lens)
-          (hsPkgs.memory)
-          (hsPkgs.network-mux)
-          (hsPkgs.ouroboros-consensus)
-          (hsPkgs.ouroboros-network)
-          (hsPkgs.resourcet)
-          (hsPkgs.sqlite-simple)
-          (hsPkgs.serialise)
-          (hsPkgs.stm)
-          (hsPkgs.tagged)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.typed-protocols)
-          (hsPkgs.unliftio-core)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+          (hsPkgs."cardano-sl" or (buildDepError "cardano-sl"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+          (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."network-mux" or (buildDepError "network-mux"))
+          (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+          (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."sqlite-simple" or (buildDepError "sqlite-simple"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+          (hsPkgs."unliftio-core" or (buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
+        buildable = true;
         };
       exes = {
         "cardano-byron-proxy" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.async)
-            (hsPkgs.cardano-byron-proxy)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cardano-sl)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-infra)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cborg)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.cryptonite)
-            (hsPkgs.directory)
-            (hsPkgs.exceptions)
-            (hsPkgs.filepath)
-            (hsPkgs.iohk-monitoring)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.lens)
-            (hsPkgs.network)
-            (hsPkgs.optparse-applicative)
-            (hsPkgs.ouroboros-consensus)
-            (hsPkgs.ouroboros-network)
-            (hsPkgs.random)
-            (hsPkgs.reflection)
-            (hsPkgs.resourcet)
-            (hsPkgs.serialise)
-            (hsPkgs.stm)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.transformers)
-            (hsPkgs.typed-protocols)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."cardano-byron-proxy" or (buildDepError "cardano-byron-proxy"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cardano-sl" or (buildDepError "cardano-sl"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."exceptions" or (buildDepError "exceptions"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
+            (hsPkgs."resourcet" or (buildDepError "resourcet"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
+          buildable = true;
           };
         "cddl-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-byron-proxy)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.cborg)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.filepath)
-            (hsPkgs.ouroboros-consensus)
-            (hsPkgs.process-extras)
-            (hsPkgs.reflection)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-byron-proxy" or (buildDepError "cardano-byron-proxy"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+            (hsPkgs."process-extras" or (buildDepError "process-extras"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,43 +52,46 @@
       synopsis = "Type classes abstracting over cryptography primitives for Cardano";
       description = "Type classes abstracting over cryptography primitives for Cardano";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cryptonite)
-          (hsPkgs.deepseq)
-          (hsPkgs.memory)
-          (hsPkgs.reflection)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       tests = {
         "test-crypto" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-crypto-class)
-            (hsPkgs.cborg)
-            (hsPkgs.cryptonite)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "13e7ffbc142eb1b9d7266c8f5373d787acb65266";
-      sha256 = "1dkral9wxd84zwcxrvids94zb2hp4g9wykxhwfj2pjih0qm8h9ng";
+      rev = "5c575d46afbfe333de0ccba70b084db8302abf42";
+      sha256 = "1v1q20fjb6klcdhl9mhpvd10j6vc7biwk91dgyfp6ld7xvj2703x";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,29 +52,31 @@
       synopsis = "Test helpers from cardano-crypto exposed to other packages";
       description = "Test helpers from cardano-crypto exposed to other packages";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-binary-test)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-crypto-wrapper)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cardano-prelude-test)
-          (hsPkgs.cryptonite)
-          (hsPkgs.hedgehog)
-          (hsPkgs.memory)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-binary-test" or (buildDepError "cardano-binary-test"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."memory" or (buildDepError "memory"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
-      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
+      rev = "181f69af290412abecefc07e1b26e77a453755ff";
+      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,54 +52,58 @@
       synopsis = "Cryptographic primitives used in the Cardano project";
       description = "Cryptographic primitives used in the Cardano project";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.base64-bytestring)
-          (hsPkgs.base64-bytestring-type)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cryptonite)
-          (hsPkgs.cryptonite-openssl)
-          (hsPkgs.data-default)
-          (hsPkgs.formatting)
-          (hsPkgs.memory)
-          (hsPkgs.mtl)
-          (hsPkgs.scrypt)
-          (hsPkgs.text)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+          (hsPkgs."base64-bytestring-type" or (buildDepError "base64-bytestring-type"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."cryptonite-openssl" or (buildDepError "cryptonite-openssl"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."scrypt" or (buildDepError "scrypt"))
+          (hsPkgs."text" or (buildDepError "text"))
           ];
+        buildable = true;
         };
       tests = {
         "test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-binary-test)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cardano-prelude-test)
-            (hsPkgs.cryptonite)
-            (hsPkgs.formatting)
-            (hsPkgs.hedgehog)
-            (hsPkgs.memory)
-            (hsPkgs.text)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-binary-test" or (buildDepError "cardano-binary-test"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."text" or (buildDepError "text"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
-      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
+      rev = "181f69af290412abecefc07e1b26e77a453755ff";
+      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto.nix
+++ b/nix/.stack.nix/cardano-crypto.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { golden-tests = false; golden-tests-exe = false; };
     package = {
@@ -13,69 +52,75 @@
       synopsis = "Cryptography primitives for cardano";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.memory)
-          (hsPkgs.deepseq)
-          (hsPkgs.bytestring)
-          (hsPkgs.basement)
-          (hsPkgs.foundation)
-          (hsPkgs.cryptonite)
-          (hsPkgs.cryptonite-openssl)
-          (hsPkgs.hashable)
-          (hsPkgs.integer-gmp)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."basement" or (buildDepError "basement"))
+          (hsPkgs."foundation" or (buildDepError "foundation"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."cryptonite-openssl" or (buildDepError "cryptonite-openssl"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
           ];
+        buildable = true;
         };
       exes = {
         "golden-tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.basement)
-            (hsPkgs.foundation)
-            (hsPkgs.memory)
-            (hsPkgs.bytestring)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            ] ++ (pkgs.lib).optional (flags.golden-tests-exe) (hsPkgs.inspector);
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            ] ++ (pkgs.lib).optional (flags.golden-tests-exe) (hsPkgs."inspector" or (buildDepError "inspector"));
+          buildable = if flags.golden-tests-exe then true else false;
           };
         };
       tests = {
         "cardano-crypto-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.memory)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.basement)
-            (hsPkgs.foundation)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
             ];
+          buildable = true;
           };
         "cardano-crypto-golden-tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.basement)
-            (hsPkgs.foundation)
-            (hsPkgs.memory)
-            (hsPkgs.bytestring)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            ] ++ (pkgs.lib).optional (flags.golden-tests) (hsPkgs.inspector);
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            ] ++ (pkgs.lib).optional (flags.golden-tests) (hsPkgs."inspector" or (buildDepError "inspector"));
+          buildable = if flags.golden-tests then true else false;
           };
         };
       benchmarks = {
         "cardano-crypto-bench" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.memory)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.gauge)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."gauge" or (buildDepError "gauge"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,42 +52,52 @@
       synopsis = "Test helpers from cardano-ledger exposed to other packages";
       description = "Test helpers from cardano-ledger exposed to other packages";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-binary-test)
-          (hsPkgs.cardano-ledger)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-crypto-test)
-          (hsPkgs.cardano-crypto-wrapper)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cardano-prelude-test)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.directory)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.hedgehog)
-          (hsPkgs.mtl)
-          (hsPkgs.optparse-applicative)
-          (hsPkgs.tasty)
-          (hsPkgs.tasty-hedgehog)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-binary-test" or (buildDepError "cardano-binary-test"))
+          (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-test" or (buildDepError "cardano-crypto-test"))
+          (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."cs-blockchain" or (buildDepError "cs-blockchain"))
+          (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."generic-monoid" or (buildDepError "generic-monoid"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."small-steps" or (buildDepError "small-steps"))
+          (hsPkgs."streaming" or (buildDepError "streaming"))
+          (hsPkgs."tasty" or (buildDepError "tasty"))
+          (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
-      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
+      rev = "181f69af290412abecefc07e1b26e77a453755ff";
+      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; test-normal-form = false; };
     package = {
@@ -13,112 +52,116 @@
       synopsis = "The blockchain layer of Cardano";
       description = "The blockchain layer of Cardano";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.base58-bytestring)
-          (hsPkgs.base64-bytestring-type)
-          (hsPkgs.bimap)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-crypto-wrapper)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.containers)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.concurrency)
-          (hsPkgs.cryptonite)
-          (hsPkgs.Cabal)
-          (hsPkgs.deepseq)
-          (hsPkgs.digest)
-          (hsPkgs.directory)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.megaparsec)
-          (hsPkgs.memory)
-          (hsPkgs.mtl)
-          (hsPkgs.resourcet)
-          (hsPkgs.streaming)
-          (hsPkgs.streaming-binary)
-          (hsPkgs.streaming-bytestring)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base58-bytestring" or (buildDepError "base58-bytestring"))
+          (hsPkgs."base64-bytestring-type" or (buildDepError "base64-bytestring-type"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."concurrency" or (buildDepError "concurrency"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."Cabal" or (buildDepError "Cabal"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."digest" or (buildDepError "digest"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."streaming" or (buildDepError "streaming"))
+          (hsPkgs."streaming-binary" or (buildDepError "streaming-binary"))
+          (hsPkgs."streaming-bytestring" or (buildDepError "streaming-bytestring"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       tests = {
         "cardano-ledger-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.bimap)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-binary-test)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-crypto-test)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cardano-prelude-test)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cs-blockchain)
-            (hsPkgs.cs-ledger)
-            (hsPkgs.directory)
-            (hsPkgs.filepath)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-monoid)
-            (hsPkgs.hedgehog)
-            (hsPkgs.lens)
-            (hsPkgs.mtl)
-            (hsPkgs.optparse-applicative)
-            (hsPkgs.resourcet)
-            (hsPkgs.small-steps)
-            (hsPkgs.streaming)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hedgehog)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.vector)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."bimap" or (buildDepError "bimap"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-binary-test" or (buildDepError "cardano-binary-test"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-crypto-test" or (buildDepError "cardano-crypto-test"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cs-blockchain" or (buildDepError "cs-blockchain"))
+            (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-monoid" or (buildDepError "generic-monoid"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."resourcet" or (buildDepError "resourcet"))
+            (hsPkgs."small-steps" or (buildDepError "small-steps"))
+            (hsPkgs."streaming" or (buildDepError "streaming"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."vector" or (buildDepError "vector"))
             ];
+          buildable = true;
           };
         "epoch-validation-normal-form-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.cardano-crypto-test)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cardano-prelude-test)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.directory)
-            (hsPkgs.filepath)
-            (hsPkgs.formatting)
-            (hsPkgs.hedgehog)
-            (hsPkgs.optparse-applicative)
-            (hsPkgs.resourcet)
-            (hsPkgs.silently)
-            (hsPkgs.streaming)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hedgehog)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-crypto-test" or (buildDepError "cardano-crypto-test"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."resourcet" or (buildDepError "resourcet"))
+            (hsPkgs."silently" or (buildDepError "silently"))
+            (hsPkgs."streaming" or (buildDepError "streaming"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
             ];
+          buildable = if !flags.test-normal-form then false else true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "a1de5b52c32255464564a6c5a8a9e474086e3875";
-      sha256 = "1426q6x4wbllimy4v6dgj36mj4cha14rkfn6jhscamhgmaxphcqr";
+      rev = "181f69af290412abecefc07e1b26e77a453755ff";
+      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,37 +52,39 @@
       synopsis = "Utility types and functions for testing Cardano";
       description = "Utility types and functions for testing Cardano";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-pretty)
-          (hsPkgs.attoparsec)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.formatting)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.pretty-show)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.text)
-          (hsPkgs.template-haskell)
-          (hsPkgs.time)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."time" or (buildDepError "time"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "b9bf62f2bab90539809bee13620fe7d29b35928d";
-      sha256 = "0fzk6z3dgnz5wrj7zp3gxzrf11hcik22ibp5z4i8d7d7hg0ngs9h";
+      rev = "ad19158c7599bc5d50fe7cb0111a1488a139a381";
+      sha256 = "172il8sw6ip84mfw1gvrrqm10vb3hccphj4v4jqyqdjxshmj1r8g";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,65 +52,68 @@
       synopsis = "A Prelude replacement for the Cardano project";
       description = "A Prelude replacement for the Cardano project";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.array)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cborg)
-          (hsPkgs.containers)
-          (hsPkgs.formatting)
-          (hsPkgs.ghc-heap)
-          (hsPkgs.ghc-prim)
-          (hsPkgs.hashable)
-          (hsPkgs.integer-gmp)
-          (hsPkgs.mtl)
-          (hsPkgs.nonempty-containers)
-          (hsPkgs.protolude)
-          (hsPkgs.tagged)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."ghc-heap" or (buildDepError "ghc-heap"))
+          (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."nonempty-containers" or (buildDepError "nonempty-containers"))
+          (hsPkgs."protolude" or (buildDepError "protolude"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       tests = {
         "cardano-prelude-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.aeson)
-            (hsPkgs.aeson-pretty)
-            (hsPkgs.attoparsec)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.bytestring)
-            (hsPkgs.canonical-json)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.containers)
-            (hsPkgs.cryptonite)
-            (hsPkgs.formatting)
-            (hsPkgs.ghc-heap)
-            (hsPkgs.ghc-prim)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.pretty-show)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.random)
-            (hsPkgs.text)
-            (hsPkgs.template-haskell)
-            (hsPkgs.time)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+            (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."ghc-heap" or (buildDepError "ghc-heap"))
+            (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "b9bf62f2bab90539809bee13620fe7d29b35928d";
-      sha256 = "0fzk6z3dgnz5wrj7zp3gxzrf11hcik22ibp5z4i8d7d7hg0ngs9h";
+      rev = "ad19158c7599bc5d50fe7cb0111a1488a139a381";
+      sha256 = "172il8sw6ip84mfw1gvrrqm10vb3hccphj4v4jqyqdjxshmj1r8g";
       });
     }

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,59 +52,63 @@
       synopsis = "";
       description = "Please see the README on GitHub at <https://github.com/githubuser/cardano-shell#readme>";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.base)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.Cabal)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.concurrency)
-          (hsPkgs.containers)
-          (hsPkgs.directory)
-          (hsPkgs.formatting)
-          (hsPkgs.process)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.async)
-          (hsPkgs.text)
-          (hsPkgs.transformers)
-          ] ++ (pkgs.lib).optional (system.isWindows) (hsPkgs.Win32);
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."Cabal" or (buildDepError "Cabal"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."concurrency" or (buildDepError "concurrency"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          ] ++ (pkgs.lib).optional (system.isWindows) (hsPkgs."Win32" or (buildDepError "Win32"));
+        buildable = true;
         };
       exes = {
         "node-ipc" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-shell)
-            (hsPkgs.cardano-prelude)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-shell" or (buildDepError "cardano-shell"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
             ];
+          buildable = true;
           };
         };
       tests = {
         "cardano-shell-test" = {
           depends = [
-            (hsPkgs.aeson)
-            (hsPkgs.base)
-            (hsPkgs.cardano-shell)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.process)
-            (hsPkgs.yaml)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-state-machine)
-            (hsPkgs.tree-diff)
-            (hsPkgs.hspec)
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-shell" or (buildDepError "cardano-shell"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-state-machine" or (buildDepError "quickcheck-state-machine"))
+            (hsPkgs."tree-diff" or (buildDepError "tree-diff"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "8b8437fa2c0cd7e0c1f0ee94ae1565dbcf5617d0";
-      sha256 = "18mq0cq5miy6ls60nfp7crh6l72qgdcvv4fsqfcwiv4sqwc5k3mg";
+      rev = "8abae427c44f0b447117f78e2c1f5006dac2edf8";
+      sha256 = "1j4nnsiagvv1yqfr4h9ailnnd7iw62vim1w7bc0sb5blngfjgvjr";
       });
     postUnpack = "sourceRoot+=/cardano-shell; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-binary-test.nix
+++ b/nix/.stack.nix/cardano-sl-binary-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-binary-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-binary-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,40 +52,42 @@
       synopsis = "Cardano SL - binary serializarion (tests)";
       description = "This package contains test helpers for cardano-sl-binary.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.QuickCheck)
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-util-test)
-          (hsPkgs.cborg)
-          (hsPkgs.cereal)
-          (hsPkgs.containers)
-          (hsPkgs.formatting)
-          (hsPkgs.half)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.mtl)
-          (hsPkgs.pretty-show)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.safecopy)
-          (hsPkgs.serokell-util)
-          (hsPkgs.text)
-          (hsPkgs.universum)
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."half" or (buildDepError "half"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."universum" or (buildDepError "universum"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-binary.nix
+++ b/nix/.stack.nix/cardano-sl-binary.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-binary"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-binary"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,80 +52,83 @@
       synopsis = "Cardano SL - binary serialization";
       description = "This package defines a type class for binary serialization,\nhelpers and instances.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.base)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cborg)
-          (hsPkgs.cereal)
-          (hsPkgs.containers)
-          (hsPkgs.digest)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.lens)
-          (hsPkgs.recursion-schemes)
-          (hsPkgs.safecopy)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.serokell-util)
-          (hsPkgs.tagged)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.th-utilities)
-          (hsPkgs.time-units)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."digest" or (buildDepError "digest"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."th-utilities" or (buildDepError "th-utilities"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "binary-test" = {
           depends = [
-            (hsPkgs.QuickCheck)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.cborg)
-            (hsPkgs.cereal)
-            (hsPkgs.containers)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.half)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.mtl)
-            (hsPkgs.pretty-show)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.safecopy)
-            (hsPkgs.serokell-util)
-            (hsPkgs.tagged)
-            (hsPkgs.text)
-            (hsPkgs.formatting)
-            (hsPkgs.time-units)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."cereal" or (buildDepError "cereal"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."half" or (buildDepError "half"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."safecopy" or (buildDepError "safecopy"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."tagged" or (buildDepError "tagged"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
-            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
+            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-chain-test.nix
+++ b/nix/.stack.nix/cardano-sl-chain-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-chain-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-chain-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "rupert.horlick@iohk.io";
       author = "Rupert Horlick";
@@ -13,47 +52,49 @@
       synopsis = "Cardano SL - arbitrary instances for cardano-sl-chain";
       description = "Cardano SL - arbitrary instances for cardano-sl-chain";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.base)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-sl-binary-test)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-core-test)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-crypto-test)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cardano-sl-util-test)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default)
-          (hsPkgs.formatting)
-          (hsPkgs.generic-arbitrary)
-          (hsPkgs.hedgehog)
-          (hsPkgs.pvss)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.random)
-          (hsPkgs.reflection)
-          (hsPkgs.serokell-util)
-          (hsPkgs.time-units)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."pvss" or (buildDepError "pvss"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/chain/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-chain.nix
+++ b/nix/.stack.nix/cardano-sl-chain.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-chain"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-chain"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,141 +52,145 @@
       synopsis = "Cardano SL - transaction processing";
       description = "Cardano SL - transaction processing";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-options)
-          (hsPkgs.array)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.Cabal)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cborg)
-          (hsPkgs.cereal)
-          (hsPkgs.conduit)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default)
-          (hsPkgs.deepseq)
-          (hsPkgs.ekg-core)
-          (hsPkgs.ether)
-          (hsPkgs.exceptions)
-          (hsPkgs.extra)
-          (hsPkgs.filepath)
-          (hsPkgs.fmt)
-          (hsPkgs.formatting)
-          (hsPkgs.formatting)
-          (hsPkgs.free)
-          (hsPkgs.generic-arbitrary)
-          (hsPkgs.hashable)
-          (hsPkgs.lens)
-          (hsPkgs.lrucache)
-          (hsPkgs.memory)
-          (hsPkgs.mmorph)
-          (hsPkgs.mono-traversable)
-          (hsPkgs.mtl)
-          (hsPkgs.neat-interpolation)
-          (hsPkgs.megaparsec)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.reflection)
-          (hsPkgs.safecopy)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.serokell-util)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-options" or (buildDepError "aeson-options"))
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."Cabal" or (buildDepError "Cabal"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."ether" or (buildDepError "ether"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."extra" or (buildDepError "extra"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."fmt" or (buildDepError "fmt"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."free" or (buildDepError "free"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."lrucache" or (buildDepError "lrucache"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."mono-traversable" or (buildDepError "mono-traversable"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."neat-interpolation" or (buildDepError "neat-interpolation"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "chain-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.aeson)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-binary-test)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-core-test)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-crypto-test)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.containers)
-            (hsPkgs.cryptonite)
-            (hsPkgs.data-default)
-            (hsPkgs.fmt)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.lens)
-            (hsPkgs.mtl)
-            (hsPkgs.pvss)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.random)
-            (hsPkgs.serokell-util)
-            (hsPkgs.formatting)
-            (hsPkgs.time-units)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.vector)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."fmt" or (buildDepError "fmt"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."pvss" or (buildDepError "pvss"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."vector" or (buildDepError "vector"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
             ];
+          buildable = true;
           };
         };
       benchmarks = {
         "block-bench" = {
           depends = [
-            (hsPkgs.QuickCheck)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.criterion)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-core-test)
-            (hsPkgs.cardano-sl-crypto-test)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.containers)
-            (hsPkgs.data-default)
-            (hsPkgs.deepseq)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.random)
-            (hsPkgs.text)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.vector)
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+            (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."vector" or (buildDepError "vector"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/chain; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-core-test.nix
+++ b/nix/.stack.nix/cardano-sl-core-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-core-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-core-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "IOHK <support@iohk.io>";
       author = "IOHK";
@@ -13,40 +52,42 @@
       synopsis = "Cardano SL - core functionality (tests)";
       description = "QuickCheck Arbitrary instances for the Cardano SL core\nfunctionality.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.QuickCheck)
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-binary-test)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-crypto-test)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cardano-sl-util-test)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.generic-arbitrary)
-          (hsPkgs.hedgehog)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.random)
-          (hsPkgs.serokell-util)
-          (hsPkgs.text)
-          (hsPkgs.time-units)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/core/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-core.nix
+++ b/nix/.stack.nix/cardano-sl-core.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { asserts = true; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-core"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-core"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,104 +52,107 @@
       synopsis = "Cardano SL - core";
       description = "Cardano SL - core";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-options)
-          (hsPkgs.ansi-terminal)
-          (hsPkgs.base)
-          (hsPkgs.base58-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cborg)
-          (hsPkgs.cereal)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default)
-          (hsPkgs.deepseq)
-          (hsPkgs.deriving-compat)
-          (hsPkgs.ekg-core)
-          (hsPkgs.ether)
-          (hsPkgs.exceptions)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.http-api-data)
-          (hsPkgs.lens)
-          (hsPkgs.megaparsec)
-          (hsPkgs.memory)
-          (hsPkgs.mmorph)
-          (hsPkgs.monad-control)
-          (hsPkgs.mtl)
-          (hsPkgs.random)
-          (hsPkgs.reflection)
-          (hsPkgs.resourcet)
-          (hsPkgs.safecopy)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.safecopy)
-          (hsPkgs.serokell-util)
-          (hsPkgs.servant)
-          (hsPkgs.stm)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.transformers-base)
-          (hsPkgs.transformers-lift)
-          (hsPkgs.universum)
-          (hsPkgs.unliftio)
-          (hsPkgs.unliftio-core)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-options" or (buildDepError "aeson-options"))
+          (hsPkgs."ansi-terminal" or (buildDepError "ansi-terminal"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base58-bytestring" or (buildDepError "base58-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."deriving-compat" or (buildDepError "deriving-compat"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."ether" or (buildDepError "ether"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
+          (hsPkgs."transformers-lift" or (buildDepError "transformers-lift"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unliftio" or (buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "core-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-binary-test)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-crypto-test)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.containers)
-            (hsPkgs.cryptonite)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.random)
-            (hsPkgs.serokell-util)
-            (hsPkgs.text)
-            (hsPkgs.time-units)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
-            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
+            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-crypto-test.nix
+++ b/nix/.stack.nix/cardano-sl-crypto-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-crypto-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-crypto-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,33 +52,35 @@
       synopsis = "Cardano SL - arbitrary instances for cardano-sl-crypto";
       description = "This package contains arbitrary instances for the cryptography primitives used in Cardano SL.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.QuickCheck)
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-binary-test)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cardano-sl-util-test)
-          (hsPkgs.cryptonite)
-          (hsPkgs.generic-arbitrary)
-          (hsPkgs.hedgehog)
-          (hsPkgs.memory)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.universum)
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."universum" or (buildDepError "universum"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-crypto.nix
+++ b/nix/.stack.nix/cardano-sl-crypto.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-crypto"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-crypto"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,77 +52,80 @@
       synopsis = "Cardano SL - cryptography primitives";
       description = "This package contains cryptography primitives used in Cardano SL.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.base)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-crypto)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cborg)
-          (hsPkgs.cereal)
-          (hsPkgs.cryptonite)
-          (hsPkgs.cryptonite-openssl)
-          (hsPkgs.data-default)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.lens)
-          (hsPkgs.memory)
-          (hsPkgs.mtl)
-          (hsPkgs.pvss)
-          (hsPkgs.reflection)
-          (hsPkgs.safecopy)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.scrypt)
-          (hsPkgs.serokell-util)
-          (hsPkgs.text)
-          (hsPkgs.formatting)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."cryptonite-openssl" or (buildDepError "cryptonite-openssl"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."pvss" or (buildDepError "pvss"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."scrypt" or (buildDepError "scrypt"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "crypto-test" = {
           depends = [
-            (hsPkgs.QuickCheck)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-binary-test)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.cryptonite)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.memory)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.text)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-db-test.nix
+++ b/nix/.stack.nix/cardano-sl-db-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-db-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-db-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "IOHK <support@iohk.io>";
       author = "IOHK";
@@ -13,30 +52,32 @@
       synopsis = "Cardano SL - arbitrary instances for cardano-sl-db";
       description = "Cardano SL - arbitrary instances for cardano-sl-db";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.QuickCheck)
-          (hsPkgs.base)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-chain-test)
-          (hsPkgs.cardano-sl-core-test)
-          (hsPkgs.cardano-sl-crypto-test)
-          (hsPkgs.cardano-sl-db)
-          (hsPkgs.cardano-sl-util-test)
-          (hsPkgs.generic-arbitrary)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+          (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+          (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+          (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+          (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/db/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-db.nix
+++ b/nix/.stack.nix/cardano-sl-db.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-db"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-db"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,84 +52,87 @@
       synopsis = "Cardano SL - basic DB interfaces";
       description = "Cardano SL - basic DB interfaces";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.base)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.concurrent-extra)
-          (hsPkgs.conduit)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default)
-          (hsPkgs.directory)
-          (hsPkgs.ekg-core)
-          (hsPkgs.ether)
-          (hsPkgs.exceptions)
-          (hsPkgs.extra)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.lens)
-          (hsPkgs.lrucache)
-          (hsPkgs.memory)
-          (hsPkgs.mmorph)
-          (hsPkgs.mtl)
-          (hsPkgs.resourcet)
-          (hsPkgs.rocksdb-haskell-ng)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.serokell-util)
-          (hsPkgs.stm)
-          (hsPkgs.tagged)
-          (hsPkgs.text)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.universum)
-          (hsPkgs.unliftio)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."concurrent-extra" or (buildDepError "concurrent-extra"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."ether" or (buildDepError "ether"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."extra" or (buildDepError "extra"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."lrucache" or (buildDepError "lrucache"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."rocksdb-haskell-ng" or (buildDepError "rocksdb-haskell-ng"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unliftio" or (buildDepError "unliftio"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "db-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-chain-test)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-core-test)
-            (hsPkgs.cardano-sl-db)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.data-default)
-            (hsPkgs.filepath)
-            (hsPkgs.hedgehog)
-            (hsPkgs.mtl)
-            (hsPkgs.lens)
-            (hsPkgs.temporary)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+            (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/db; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-infra-test.nix
+++ b/nix/.stack.nix/cardano-sl-infra-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-infra-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-infra-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2018 IOHK";
       maintainer = "IOHK <support@iohk.io>";
       author = "IOHK";
@@ -13,41 +52,43 @@
       synopsis = "Cardano SL - generators for cardano-sl-infra";
       description = "This package contains generators for the infrastructural data types used in Cardano SL.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.QuickCheck)
-          (hsPkgs.async)
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-sl-binary-test)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-chain-test)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-core-test)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-crypto-test)
-          (hsPkgs.cardano-sl-infra)
-          (hsPkgs.cardano-sl-networking)
-          (hsPkgs.cardano-sl-util-test)
-          (hsPkgs.containers)
-          (hsPkgs.dns)
-          (hsPkgs.generic-arbitrary)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.iproute)
-          (hsPkgs.kademlia)
-          (hsPkgs.universum)
-          (hsPkgs.yaml)
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+          (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+          (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+          (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."dns" or (buildDepError "dns"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."iproute" or (buildDepError "iproute"))
+          (hsPkgs."kademlia" or (buildDepError "kademlia"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/infra/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-infra.nix
+++ b/nix/.stack.nix/cardano-sl-infra.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-infra"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-infra"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,102 +52,105 @@
       synopsis = "Cardano SL - infrastructural";
       description = "Cardano SL - infrastructural";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.async)
-          (hsPkgs.base)
-          (hsPkgs.base64-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-db)
-          (hsPkgs.cardano-sl-networking)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.clock)
-          (hsPkgs.conduit)
-          (hsPkgs.containers)
-          (hsPkgs.directory)
-          (hsPkgs.dns)
-          (hsPkgs.ekg-core)
-          (hsPkgs.ekg-statsd)
-          (hsPkgs.ekg-wai)
-          (hsPkgs.ether)
-          (hsPkgs.exceptions)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.http-client)
-          (hsPkgs.http-client-tls)
-          (hsPkgs.iproute)
-          (hsPkgs.kademlia)
-          (hsPkgs.lens)
-          (hsPkgs.megaparsec)
-          (hsPkgs.mtl)
-          (hsPkgs.network-info)
-          (hsPkgs.network-transport)
-          (hsPkgs.network-transport-tcp)
-          (hsPkgs.lzma-conduit)
-          (hsPkgs.optparse-applicative)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.serokell-util)
-          (hsPkgs.stm)
-          (hsPkgs.tar)
-          (hsPkgs.time)
-          (hsPkgs.tagged)
-          (hsPkgs.vector)
-          (hsPkgs.text)
-          (hsPkgs.time-units)
-          (hsPkgs.network-transport)
-          (hsPkgs.universum)
-          (hsPkgs.unliftio)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.yaml)
-          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+          (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."clock" or (buildDepError "clock"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."dns" or (buildDepError "dns"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."ekg-statsd" or (buildDepError "ekg-statsd"))
+          (hsPkgs."ekg-wai" or (buildDepError "ekg-wai"))
+          (hsPkgs."ether" or (buildDepError "ether"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."iproute" or (buildDepError "iproute"))
+          (hsPkgs."kademlia" or (buildDepError "kademlia"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."network-info" or (buildDepError "network-info"))
+          (hsPkgs."network-transport" or (buildDepError "network-transport"))
+          (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+          (hsPkgs."lzma-conduit" or (buildDepError "lzma-conduit"))
+          (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."tar" or (buildDepError "tar"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."network-transport" or (buildDepError "network-transport"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unliftio" or (buildDepError "unliftio"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
+          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs."unix" or (buildDepError "unix"));
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "infra-test" = {
           depends = [
-            (hsPkgs.QuickCheck)
-            (hsPkgs.async)
-            (hsPkgs.aeson)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-sl-binary-test)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-chain-test)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-core-test)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-crypto-test)
-            (hsPkgs.cardano-sl-infra)
-            (hsPkgs.cardano-sl-networking)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.containers)
-            (hsPkgs.dns)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.iproute)
-            (hsPkgs.kademlia)
-            (hsPkgs.universum)
-            (hsPkgs.yaml)
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+            (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+            (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."dns" or (buildDepError "dns"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."iproute" or (buildDepError "iproute"))
+            (hsPkgs."kademlia" or (buildDepError "kademlia"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/infra; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-networking.nix
+++ b/nix/.stack.nix/cardano-sl-networking.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { benchmarks = false; };
     package = {
       specVersion = "1.20";
-      identifier = { name = "cardano-sl-networking"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-networking"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "";
       maintainer = "";
       author = "";
@@ -13,158 +52,166 @@
       synopsis = "";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-options)
-          (hsPkgs.async)
-          (hsPkgs.attoparsec)
-          (hsPkgs.base)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.containers)
-          (hsPkgs.ekg-core)
-          (hsPkgs.formatting)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.lens)
-          (hsPkgs.mtl)
-          (hsPkgs.mtl)
-          (hsPkgs.network)
-          (hsPkgs.network-transport)
-          (hsPkgs.network-transport-tcp)
-          (hsPkgs.random)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.scientific)
-          (hsPkgs.stm)
-          (hsPkgs.text)
-          (hsPkgs.these)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-options" or (buildDepError "aeson-options"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."network-transport" or (buildDepError "network-transport"))
+          (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."these" or (buildDepError "these"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           ];
+        buildable = true;
         };
       exes = {
         "ping-pong" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.async)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-sl-networking)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.contravariant)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-tcp)
-            (hsPkgs.random)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."contravariant" or (buildDepError "contravariant"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+            (hsPkgs."random" or (buildDepError "random"))
             ];
+          buildable = true;
           };
         "bench-sender" = {
           depends = [
-            (hsPkgs.async)
-            (hsPkgs.base)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.contravariant)
-            (hsPkgs.lens)
-            (hsPkgs.MonadRandom)
-            (hsPkgs.mtl)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-tcp)
-            (hsPkgs.optparse-simple)
-            (hsPkgs.random)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.serokell-util)
-            (hsPkgs.time)
-            (hsPkgs.time-units)
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."contravariant" or (buildDepError "contravariant"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."MonadRandom" or (buildDepError "MonadRandom"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+            (hsPkgs."optparse-simple" or (buildDepError "optparse-simple"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
             ];
+          buildable = if flags.benchmarks then true else false;
           };
         "bench-receiver" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.contravariant)
-            (hsPkgs.network-transport-tcp)
-            (hsPkgs.optparse-simple)
-            (hsPkgs.random)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.serokell-util)
-            (hsPkgs.text)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."contravariant" or (buildDepError "contravariant"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+            (hsPkgs."optparse-simple" or (buildDepError "optparse-simple"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."text" or (buildDepError "text"))
             ];
+          buildable = if flags.benchmarks then true else false;
           };
         "bench-log-reader" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.attoparsec)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.conduit)
-            (hsPkgs.conduit-extra)
-            (hsPkgs.containers)
-            (hsPkgs.lens)
-            (hsPkgs.mtl)
-            (hsPkgs.optparse-simple)
-            (hsPkgs.resourcet)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.text)
-            (hsPkgs.formatting)
-            (hsPkgs.unliftio-core)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."conduit" or (buildDepError "conduit"))
+            (hsPkgs."conduit-extra" or (buildDepError "conduit-extra"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."optparse-simple" or (buildDepError "optparse-simple"))
+            (hsPkgs."resourcet" or (buildDepError "resourcet"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."unliftio-core" or (buildDepError "unliftio-core"))
             ];
+          buildable = if flags.benchmarks then true else false;
           };
         };
       tests = {
         "cardano-sl-networking-test" = {
           depends = [
-            (hsPkgs.async)
-            (hsPkgs.base)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-sl-networking)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.containers)
-            (hsPkgs.hspec)
-            (hsPkgs.hspec-core)
-            (hsPkgs.lens)
-            (hsPkgs.mtl)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-tcp)
-            (hsPkgs.network-transport-inmemory)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.random)
-            (hsPkgs.serokell-util)
-            (hsPkgs.stm)
-            (hsPkgs.time-units)
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (buildDepError "hspec-core"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+            (hsPkgs."network-transport-inmemory" or (buildDepError "network-transport-inmemory"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
             ];
+          buildable = true;
           };
         };
       benchmarks = {
         "qdisc-simulation" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.async)
-            (hsPkgs.network-transport-tcp)
-            (hsPkgs.network-transport)
-            (hsPkgs.time-units)
-            (hsPkgs.stm)
-            (hsPkgs.mwc-random)
-            (hsPkgs.statistics)
-            (hsPkgs.vector)
-            (hsPkgs.time)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."mwc-random" or (buildDepError "mwc-random"))
+            (hsPkgs."statistics" or (buildDepError "statistics"))
+            (hsPkgs."vector" or (buildDepError "vector"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/networking; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-util-test.nix
+++ b/nix/.stack.nix/cardano-sl-util-test.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-util-test"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-util-test"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "hi@serokell.io";
       author = "Serokell";
@@ -13,48 +52,50 @@
       synopsis = "Cardano SL - general utilities (tests)";
       description = "QuickCheck Arbitrary instances for the Cardano SL general\nutilities package.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.QuickCheck)
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-pretty)
-          (hsPkgs.attoparsec)
-          (hsPkgs.base)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.cereal)
-          (hsPkgs.cryptonite)
-          (hsPkgs.directory)
-          (hsPkgs.file-embed)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.mtl)
-          (hsPkgs.pretty-show)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.safecopy)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time-units)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.yaml)
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."safecopy" or (buildDepError "safecopy"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/util/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-util.nix
+++ b/nix/.stack.nix/cardano-sl-util.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl-util"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl-util"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "support@iohk.io";
       author = "IOHK";
@@ -13,101 +52,104 @@
       synopsis = "Cardano SL - general utilities";
       description = "This package contains utility functions not specific\nto Cardano SL which extend 3rd party libraries or implement\nsomething from scratch.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.aeson)
-          (hsPkgs.auto-update)
-          (hsPkgs.base)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cborg)
-          (hsPkgs.cereal)
-          (hsPkgs.containers)
-          (hsPkgs.concurrent-extra)
-          (hsPkgs.contravariant)
-          (hsPkgs.cryptonite)
-          (hsPkgs.deepseq)
-          (hsPkgs.directory)
-          (hsPkgs.ether)
-          (hsPkgs.exceptions)
-          (hsPkgs.file-embed)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.katip)
-          (hsPkgs.lens)
-          (hsPkgs.lrucache)
-          (hsPkgs.megaparsec)
-          (hsPkgs.mmorph)
-          (hsPkgs.monad-control)
-          (hsPkgs.mtl)
-          (hsPkgs.optparse-applicative)
-          (hsPkgs.process)
-          (hsPkgs.reflection)
-          (hsPkgs.resourcet)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.serokell-util)
-          (hsPkgs.stm)
-          (hsPkgs.tagged)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.transformers-base)
-          (hsPkgs.transformers-lift)
-          (hsPkgs.universum)
-          (hsPkgs.unliftio-core)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.yaml)
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."auto-update" or (buildDepError "auto-update"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."cereal" or (buildDepError "cereal"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."concurrent-extra" or (buildDepError "concurrent-extra"))
+          (hsPkgs."contravariant" or (buildDepError "contravariant"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."ether" or (buildDepError "ether"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."katip" or (buildDepError "katip"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."lrucache" or (buildDepError "lrucache"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
+          (hsPkgs."transformers-lift" or (buildDepError "transformers-lift"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unliftio-core" or (buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
           ];
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "util-test" = {
           depends = [
-            (hsPkgs.aeson)
-            (hsPkgs.aeson-pretty)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.async)
-            (hsPkgs.canonical-json)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cereal)
-            (hsPkgs.directory)
-            (hsPkgs.file-embed)
-            (hsPkgs.filepath)
-            (hsPkgs.formatting)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.pretty-show)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.safecopy)
-            (hsPkgs.stm)
-            (hsPkgs.template-haskell)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.time-units)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.yaml)
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cereal" or (buildDepError "cereal"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."file-embed" or (buildDepError "file-embed"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."safecopy" or (buildDepError "safecopy"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
-            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
+            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/util; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-x509.nix
+++ b/nix/.stack.nix/cardano-sl-x509.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,42 +52,45 @@
       synopsis = "Tool-suite for generating x509 certificates specialized for RSA with SHA-256";
       description = "See README";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.asn1-encoding)
-          (hsPkgs.asn1-types)
-          (hsPkgs.base64-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default-class)
-          (hsPkgs.directory)
-          (hsPkgs.exceptions)
-          (hsPkgs.filepath)
-          (hsPkgs.hourglass)
-          (hsPkgs.ip)
-          (hsPkgs.text)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.x509)
-          (hsPkgs.x509-store)
-          (hsPkgs.x509-validation)
-          (hsPkgs.yaml)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."asn1-encoding" or (buildDepError "asn1-encoding"))
+          (hsPkgs."asn1-types" or (buildDepError "asn1-types"))
+          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default-class" or (buildDepError "data-default-class"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."hourglass" or (buildDepError "hourglass"))
+          (hsPkgs."ip" or (buildDepError "ip"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."x509" or (buildDepError "x509"))
+          (hsPkgs."x509-store" or (buildDepError "x509-store"))
+          (hsPkgs."x509-validation" or (buildDepError "x509-validation"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
           ];
+        buildable = true;
         };
       tests = {
         "cardano-sl-x509-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cardano-sl-x509)
-            (hsPkgs.exceptions)
-            (hsPkgs.hedgehog)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cardano-sl-x509" or (buildDepError "cardano-sl-x509"))
+            (hsPkgs."exceptions" or (buildDepError "exceptions"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/cardano-sl.nix
+++ b/nix/.stack.nix/cardano-sl.nix
@@ -1,10 +1,49 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-sl"; version = "3.0.3"; };
-      license = "MIT";
+      identifier = { name = "cardano-sl"; version = "3.1.0"; };
+      license = "Apache-2.0";
       copyright = "2016 IOHK";
       maintainer = "Serokell <hi@serokell.io>";
       author = "Serokell";
@@ -13,196 +52,200 @@
       synopsis = "Cardano SL main implementation";
       description = "Please see README.md";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = ([
-          (hsPkgs.base)
-          (hsPkgs.base64-bytestring)
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-options)
-          (hsPkgs.ansi-terminal)
-          (hsPkgs.ansi-wl-pprint)
-          (hsPkgs.async)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-sl-binary)
-          (hsPkgs.cardano-sl-binary-test)
-          (hsPkgs.cardano-sl-chain)
-          (hsPkgs.cardano-sl-chain-test)
-          (hsPkgs.cardano-sl-core)
-          (hsPkgs.cardano-sl-core-test)
-          (hsPkgs.cardano-sl-crypto)
-          (hsPkgs.cardano-sl-crypto-test)
-          (hsPkgs.cardano-sl-db)
-          (hsPkgs.cardano-sl-infra)
-          (hsPkgs.cardano-sl-networking)
-          (hsPkgs.cardano-sl-util)
-          (hsPkgs.conduit)
-          (hsPkgs.constraints)
-          (hsPkgs.containers)
-          (hsPkgs.contravariant)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default)
-          (hsPkgs.directory)
-          (hsPkgs.ekg-core)
-          (hsPkgs.ekg)
-          (hsPkgs.ether)
-          (hsPkgs.exceptions)
-          (hsPkgs.filelock)
-          (hsPkgs.filepath)
-          (hsPkgs.formatting)
-          (hsPkgs.formatting)
-          (hsPkgs.generics-sop)
-          (hsPkgs.hspec)
-          (hsPkgs.http-api-data)
-          (hsPkgs.http-client)
-          (hsPkgs.http-client-tls)
-          (hsPkgs.http-conduit)
-          (hsPkgs.http-types)
-          (hsPkgs.lens)
-          (hsPkgs.lifted-async)
-          (hsPkgs.memory)
-          (hsPkgs.monad-control)
-          (hsPkgs.mtl)
-          (hsPkgs.neat-interpolation)
-          (hsPkgs.network)
-          (hsPkgs.network-transport)
-          (hsPkgs.optparse-applicative)
-          (hsPkgs.megaparsec)
-          (hsPkgs.pvss)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.random)
-          (hsPkgs.reflection)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.serokell-util)
-          (hsPkgs.servant)
-          (hsPkgs.servant-client)
-          (hsPkgs.servant-client-core)
-          (hsPkgs.servant-server)
-          (hsPkgs.servant-swagger)
-          (hsPkgs.servant-swagger-ui)
-          (hsPkgs.servant-swagger-ui-core)
-          (hsPkgs.servant-swagger-ui-redoc)
-          (hsPkgs.stm)
-          (hsPkgs.streaming-commons)
-          (hsPkgs.swagger2)
-          (hsPkgs.tagged)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.tls)
-          (hsPkgs.transformers)
-          (hsPkgs.universum)
-          (hsPkgs.unliftio)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.wai)
-          (hsPkgs.warp)
-          (hsPkgs.warp-tls)
-          (hsPkgs.x509)
-          (hsPkgs.x509-store)
-          (hsPkgs.x509-validation)
-          (hsPkgs.yaml)
-          (hsPkgs.cborg)
-          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix)) ++ (pkgs.lib).optional (!system.isWindows && !system.isFreebsd) (hsPkgs.systemd);
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-options" or (buildDepError "aeson-options"))
+          (hsPkgs."ansi-terminal" or (buildDepError "ansi-terminal"))
+          (hsPkgs."ansi-wl-pprint" or (buildDepError "ansi-wl-pprint"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+          (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+          (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+          (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+          (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+          (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+          (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+          (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+          (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+          (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+          (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+          (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."constraints" or (buildDepError "constraints"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."contravariant" or (buildDepError "contravariant"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."ekg" or (buildDepError "ekg"))
+          (hsPkgs."ether" or (buildDepError "ether"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."filelock" or (buildDepError "filelock"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."generics-sop" or (buildDepError "generics-sop"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."http-conduit" or (buildDepError "http-conduit"))
+          (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."lifted-async" or (buildDepError "lifted-async"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."neat-interpolation" or (buildDepError "neat-interpolation"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."network-transport" or (buildDepError "network-transport"))
+          (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."pvss" or (buildDepError "pvss"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-client-core" or (buildDepError "servant-client-core"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."servant-swagger" or (buildDepError "servant-swagger"))
+          (hsPkgs."servant-swagger-ui" or (buildDepError "servant-swagger-ui"))
+          (hsPkgs."servant-swagger-ui-core" or (buildDepError "servant-swagger-ui-core"))
+          (hsPkgs."servant-swagger-ui-redoc" or (buildDepError "servant-swagger-ui-redoc"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."streaming-commons" or (buildDepError "streaming-commons"))
+          (hsPkgs."swagger2" or (buildDepError "swagger2"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."tls" or (buildDepError "tls"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unliftio" or (buildDepError "unliftio"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."wai" or (buildDepError "wai"))
+          (hsPkgs."warp" or (buildDepError "warp"))
+          (hsPkgs."warp-tls" or (buildDepError "warp-tls"))
+          (hsPkgs."x509" or (buildDepError "x509"))
+          (hsPkgs."x509-store" or (buildDepError "x509-store"))
+          (hsPkgs."x509-validation" or (buildDepError "x509-validation"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs."unix" or (buildDepError "unix"))) ++ (pkgs.lib).optional (!system.isWindows && !system.isFreebsd) (hsPkgs."systemd" or (buildDepError "systemd"));
         build-tools = [
-          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+          (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
           ];
+        buildable = true;
         };
       tests = {
         "cardano-test" = {
           depends = [
-            (hsPkgs.QuickCheck)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.cardano-sl)
-            (hsPkgs.cardano-sl-binary)
-            (hsPkgs.cardano-sl-binary-test)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-chain-test)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-core-test)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-crypto-test)
-            (hsPkgs.cardano-sl-db)
-            (hsPkgs.cardano-sl-db-test)
-            (hsPkgs.cardano-sl-infra)
-            (hsPkgs.cardano-sl-infra-test)
-            (hsPkgs.cardano-sl-networking)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.conduit)
-            (hsPkgs.containers)
-            (hsPkgs.cryptonite)
-            (hsPkgs.data-default)
-            (hsPkgs.deepseq)
-            (hsPkgs.extra)
-            (hsPkgs.filelock)
-            (hsPkgs.formatting)
-            (hsPkgs.generic-arbitrary)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.lens)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-inmemory)
-            (hsPkgs.pvss)
-            (hsPkgs.random)
-            (hsPkgs.reflection)
-            (hsPkgs.serokell-util)
-            (hsPkgs.tagged)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.time-units)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-sl" or (buildDepError "cardano-sl"))
+            (hsPkgs."cardano-sl-binary" or (buildDepError "cardano-sl-binary"))
+            (hsPkgs."cardano-sl-binary-test" or (buildDepError "cardano-sl-binary-test"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+            (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+            (hsPkgs."cardano-sl-db-test" or (buildDepError "cardano-sl-db-test"))
+            (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+            (hsPkgs."cardano-sl-infra-test" or (buildDepError "cardano-sl-infra-test"))
+            (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."conduit" or (buildDepError "conduit"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."extra" or (buildDepError "extra"))
+            (hsPkgs."filelock" or (buildDepError "filelock"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-inmemory" or (buildDepError "network-transport-inmemory"))
+            (hsPkgs."pvss" or (buildDepError "pvss"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."tagged" or (buildDepError "tagged"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
-            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
+            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
             ];
+          buildable = true;
           };
         };
       benchmarks = {
         "cardano-bench-criterion" = {
           depends = [
-            (hsPkgs.QuickCheck)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-sl)
-            (hsPkgs.cardano-sl-chain)
-            (hsPkgs.cardano-sl-chain-test)
-            (hsPkgs.cardano-sl-core)
-            (hsPkgs.cardano-sl-core-test)
-            (hsPkgs.cardano-sl-crypto)
-            (hsPkgs.cardano-sl-crypto-test)
-            (hsPkgs.cardano-sl-db)
-            (hsPkgs.cardano-sl-infra)
-            (hsPkgs.cardano-sl-networking)
-            (hsPkgs.cardano-sl-util)
-            (hsPkgs.cardano-sl-util-test)
-            (hsPkgs.conduit)
-            (hsPkgs.criterion)
-            (hsPkgs.deepseq)
-            (hsPkgs.formatting)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-inmemory)
-            (hsPkgs.optparse-applicative)
-            (hsPkgs.universum)
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-sl" or (buildDepError "cardano-sl"))
+            (hsPkgs."cardano-sl-chain" or (buildDepError "cardano-sl-chain"))
+            (hsPkgs."cardano-sl-chain-test" or (buildDepError "cardano-sl-chain-test"))
+            (hsPkgs."cardano-sl-core" or (buildDepError "cardano-sl-core"))
+            (hsPkgs."cardano-sl-core-test" or (buildDepError "cardano-sl-core-test"))
+            (hsPkgs."cardano-sl-crypto" or (buildDepError "cardano-sl-crypto"))
+            (hsPkgs."cardano-sl-crypto-test" or (buildDepError "cardano-sl-crypto-test"))
+            (hsPkgs."cardano-sl-db" or (buildDepError "cardano-sl-db"))
+            (hsPkgs."cardano-sl-infra" or (buildDepError "cardano-sl-infra"))
+            (hsPkgs."cardano-sl-networking" or (buildDepError "cardano-sl-networking"))
+            (hsPkgs."cardano-sl-util" or (buildDepError "cardano-sl-util"))
+            (hsPkgs."cardano-sl-util-test" or (buildDepError "cardano-sl-util-test"))
+            (hsPkgs."conduit" or (buildDepError "conduit"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-inmemory" or (buildDepError "network-transport-inmemory"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."universum" or (buildDepError "universum"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs))
+            (hsPkgs.buildPackages.cpphs or (pkgs.buildPackages.cpphs or (buildToolDepError "cpphs")))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "4f8cbfc63a7c741108995469a08d70202dda3e0c";
-      sha256 = "08r1zd58yqxglmynkk35vdf45546rqnffxcf48spqb158g17pydk";
+      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
+      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
       });
     postUnpack = "sourceRoot+=/lib; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,12 +52,14 @@
       synopsis = "A simple interface for logging, tracing or monitoring.";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs.contravariant);
+          (hsPkgs."base" or (buildDepError "base"))
+          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+        buildable = true;
         };
       };
     } // {

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -39,18 +39,18 @@ let
       '';
 in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { development = false; };
     package = {
-      specVersion = "2.0";
-      identifier = { name = "log-warper"; version = "1.8.10.1"; };
+      specVersion = "1.10";
+      identifier = { name = "cs-blockchain"; version = "0.1.0.0"; };
       license = "MIT";
-      copyright = "2016-2018 Serokell";
-      maintainer = "Serokell <hi@serokell.io>";
-      author = "@serokell";
-      homepage = "https://github.com/serokell/log-warper";
+      copyright = "";
+      maintainer = "formal.methods@iohk.io";
+      author = "IOHK Formal Methods Team";
+      homepage = "https://github.com/input-output-hk/cardano-chain";
       url = "";
-      synopsis = "Flexible, configurable, monadic and pretty logging";
-      description = "This package implements nice and featureful wrapper around hslogger library.";
+      synopsis = "Executable specification of the Cardano blockchain";
+      description = "";
       buildType = "Simple";
       isLocal = true;
       };
@@ -58,36 +58,42 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
-          (hsPkgs."ansi-terminal" or (buildDepError "ansi-terminal"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."containers" or (buildDepError "containers"))
-          (hsPkgs."deepseq" or (buildDepError "deepseq"))
-          (hsPkgs."directory" or (buildDepError "directory"))
-          (hsPkgs."filepath" or (buildDepError "filepath"))
-          (hsPkgs."fmt" or (buildDepError "fmt"))
-          (hsPkgs."lifted-async" or (buildDepError "lifted-async"))
-          (hsPkgs."microlens-platform" or (buildDepError "microlens-platform"))
-          (hsPkgs."monad-control" or (buildDepError "monad-control"))
-          (hsPkgs."monad-loops" or (buildDepError "monad-loops"))
-          (hsPkgs."mmorph" or (buildDepError "mmorph"))
-          (hsPkgs."mtl" or (buildDepError "mtl"))
-          (hsPkgs."o-clock" or (buildDepError "o-clock"))
-          (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."time" or (buildDepError "time"))
-          (hsPkgs."transformers" or (buildDepError "transformers"))
-          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
-          (hsPkgs."universum" or (buildDepError "universum"))
-          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
-          (hsPkgs."vector" or (buildDepError "vector"))
-          (hsPkgs."yaml" or (buildDepError "yaml"))
-          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs."unix" or (buildDepError "unix"));
+          (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
+          (hsPkgs."goblins" or (buildDepError "goblins"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."small-steps" or (buildDepError "small-steps"))
+          ];
         buildable = true;
+        };
+      tests = {
+        "chain-rules-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-ordlist" or (buildDepError "data-ordlist"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."cs-blockchain" or (buildDepError "cs-blockchain"))
+            (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
+            (hsPkgs."small-steps" or (buildDepError "small-steps"))
+            ];
+          buildable = true;
+          };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/log-warper";
-      rev = "16246d4fbf16da7984f2a4b6c42f2ed5098182e4";
-      sha256 = "11vw6h3lshhwrjbxni6z0jr6w9x2x338rv6p2b4b0rgr650pv2a9";
+      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      rev = "0d7e670952657c23a6486bfa15e9d10166351986";
+      sha256 = "1anikzb6ypi8zz973h7fap9djjbrqvw5mhqrch6av05xqkaqx3jv";
       });
+    postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -41,16 +41,16 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
-      specVersion = "1.10";
-      identifier = { name = "cardano-binary"; version = "1.5.0"; };
+      specVersion = "2.0";
+      identifier = { name = "cs-ledger"; version = "0.1.0.0"; };
       license = "MIT";
-      copyright = "2019 IOHK";
-      maintainer = "operations@iohk.io";
-      author = "IOHK";
-      homepage = "";
+      copyright = "";
+      maintainer = "formal.methods@iohk.io";
+      author = "IOHK Formal Methods Team";
+      homepage = "https://github.com/input-output-hk/cardano-chain";
       url = "";
-      synopsis = "Binary serialization for Cardano";
-      description = "This package includes the binary serialization format for Cardano";
+      synopsis = "Executable specification of Cardano ledger";
+      description = "";
       buildType = "Simple";
       isLocal = true;
       };
@@ -58,41 +58,52 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
-          (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
-          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
           (hsPkgs."containers" or (buildDepError "containers"))
-          (hsPkgs."digest" or (buildDepError "digest"))
-          (hsPkgs."formatting" or (buildDepError "formatting"))
-          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
-          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
-          (hsPkgs."tagged" or (buildDepError "tagged"))
-          (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."time" or (buildDepError "time"))
-          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."goblins" or (buildDepError "goblins"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."Unique" or (buildDepError "Unique"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."small-steps" or (buildDepError "small-steps"))
           ];
         buildable = true;
         };
       tests = {
-        "test" = {
+        "doctests" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."bytestring" or (buildDepError "bytestring"))
-            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
-            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
-            (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
-            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."doctest" or (buildDepError "doctest"))
             (hsPkgs."containers" or (buildDepError "containers"))
-            (hsPkgs."formatting" or (buildDepError "formatting"))
             (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
-            (hsPkgs."hspec" or (buildDepError "hspec"))
-            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
-            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
-            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
-            (hsPkgs."tagged" or (buildDepError "tagged"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."memory" or (buildDepError "memory"))
             (hsPkgs."text" or (buildDepError "text"))
-            (hsPkgs."vector" or (buildDepError "vector"))
+            (hsPkgs."small-steps" or (buildDepError "small-steps"))
+            (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.doctest-discover or (pkgs.buildPackages.doctest-discover or (buildToolDepError "doctest-discover")))
+            ];
+          buildable = true;
+          };
+        "ledger-rules-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bimap" or (buildDepError "bimap"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."Unique" or (buildDepError "Unique"))
+            (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
+            (hsPkgs."small-steps" or (buildDepError "small-steps"))
             ];
           buildable = true;
           };
@@ -100,9 +111,9 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-base";
-      rev = "5c575d46afbfe333de0ccba70b084db8302abf42";
-      sha256 = "1v1q20fjb6klcdhl9mhpvd10j6vc7biwk91dgyfp6ld7xvj2703x";
+      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      rev = "0d7e670952657c23a6486bfa15e9d10166351986";
+      sha256 = "1anikzb6ypi8zz973h7fap9djjbrqvw5mhqrch6av05xqkaqx3jv";
       });
-    postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -4,14 +4,14 @@
       packages = {
         "bimap" = (((hackage.bimap)."0.4.0").revisions).default;
         "binary" = (((hackage.binary)."0.8.7.0").revisions).default;
-        "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
-        "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;
-        "prometheus" = (((hackage.prometheus)."2.1.1").revisions).default;
         "containers" = (((hackage.containers)."0.5.11.0").revisions).default;
-        "splitmix" = (((hackage.splitmix)."0.0.2").revisions).default;
-        "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
-        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
+        "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;
         "generic-monoid" = (((hackage.generic-monoid)."0.1.0.0").revisions).default;
+        "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
+        "prometheus" = (((hackage.prometheus)."2.1.1").revisions).default;
+        "splitmix" = (((hackage.splitmix)."0.0.2").revisions).default;
+        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
+        "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "Win32" = (((hackage.Win32)."2.5.4.1").revisions).default;
         "aeson-options" = (((hackage.aeson-options)."0.1.0").revisions).default;
         "pvss" = (((hackage.pvss)."0.2.0").revisions).default;
@@ -29,7 +29,6 @@
         "canonical-json" = (((hackage.canonical-json)."0.6.0.0").revisions).default;
         "graphviz" = (((hackage.graphviz)."2999.20.0.3").revisions)."cde383c356bc41136ed53cd27e0800f46dbd2185600dd0de18d66d5c49739d94";
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions)."3e4f8df0f6b5d415e3c8840dc75034a63e37f56f5f8cfa1035ded16345235ac4";
-        } // {
         cardano-byron-proxy = ./cardano-byron-proxy.nix;
         iohk-monitoring = ./iohk-monitoring.nix;
         contra-tracer = ./contra-tracer.nix;
@@ -82,5 +81,18 @@
       compiler.nix-name = "ghc865";
       };
   resolver = "lts-13.26";
+  modules = [
+    ({ lib, ... }:
+      { packages = {}; })
+    {
+      packages = {
+        "cardano-byron-proxy" = {
+          package = {
+            ghcOptions = "-Wall -Werror -Wcompat -fwarn-redundant-constraints -fwarn-incomplete-patterns -fwarn-unused-imports -Wincomplete-record-updates -Wincomplete-uni-patterns";
+            };
+          };
+        };
+      }
+    ];
   compiler = "ghc-8.6.5";
   }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -50,7 +50,6 @@
         network-mux = ./network-mux.nix;
         typed-protocols = ./typed-protocols.nix;
         typed-protocols-cbor = ./typed-protocols-cbor.nix;
-        canonical-json = ./canonical-json.nix;
         cardano-sl = ./cardano-sl.nix;
         cardano-sl-binary = ./cardano-sl-binary.nix;
         cardano-sl-binary-test = ./cardano-sl-binary-test.nix;

--- a/nix/.stack.nix/ether.nix
+++ b/nix/.stack.nix/ether.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { disable-tup-instances = false; };
     package = {
@@ -13,50 +52,54 @@
       synopsis = "Monad transformers and classes";
       description = "Ether is a Haskell library that extends @mtl@ and @transformers@ with\ntagged monad transformers and classes in a compatible way.\nIntroduction <https://int-index.github.io/ether/>";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.transformers)
-          (hsPkgs.transformers-lift)
-          (hsPkgs.mtl)
-          (hsPkgs.mmorph)
-          (hsPkgs.monad-control)
-          (hsPkgs.transformers-base)
-          (hsPkgs.writer-cps-mtl)
-          (hsPkgs.exceptions)
-          (hsPkgs.template-haskell)
-          (hsPkgs.tagged)
-          (hsPkgs.reflection)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."transformers-lift" or (buildDepError "transformers-lift"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
+          (hsPkgs."writer-cps-mtl" or (buildDepError "writer-cps-mtl"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
           ];
+        buildable = true;
         };
       tests = {
         "regression" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.transformers)
-            (hsPkgs.mtl)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.ghc-prim)
-            (hsPkgs.lens)
-            (hsPkgs.ether)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."ether" or (buildDepError "ether"))
             ];
+          buildable = true;
           };
         };
       benchmarks = {
         "bench" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.mtl)
-            (hsPkgs.transformers)
-            (hsPkgs.criterion)
-            (hsPkgs.deepseq)
-            (hsPkgs.lens)
-            (hsPkgs.ether)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."ether" or (buildDepError "ether"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/goblins.nix
+++ b/nix/.stack.nix/goblins.nix
@@ -39,18 +39,18 @@ let
       '';
 in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { development = false; };
     package = {
-      specVersion = "2.0";
-      identifier = { name = "log-warper"; version = "1.8.10.1"; };
-      license = "MIT";
-      copyright = "2016-2018 Serokell";
-      maintainer = "Serokell <hi@serokell.io>";
-      author = "@serokell";
-      homepage = "https://github.com/serokell/log-warper";
+      specVersion = "1.10";
+      identifier = { name = "goblins"; version = "0.1.0.0"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "nick@topos.org.uk";
+      author = "Nicholas Clarke";
+      homepage = "https://github.com/input-output-hk/goblins";
       url = "";
-      synopsis = "Flexible, configurable, monadic and pretty logging";
-      description = "This package implements nice and featureful wrapper around hslogger library.";
+      synopsis = "Genetic algorithm based randomised testing";
+      description = "";
       buildType = "Simple";
       isLocal = true;
       };
@@ -58,36 +58,41 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
-          (hsPkgs."ansi-terminal" or (buildDepError "ansi-terminal"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."containers" or (buildDepError "containers"))
-          (hsPkgs."deepseq" or (buildDepError "deepseq"))
-          (hsPkgs."directory" or (buildDepError "directory"))
-          (hsPkgs."filepath" or (buildDepError "filepath"))
-          (hsPkgs."fmt" or (buildDepError "fmt"))
-          (hsPkgs."lifted-async" or (buildDepError "lifted-async"))
-          (hsPkgs."microlens-platform" or (buildDepError "microlens-platform"))
-          (hsPkgs."monad-control" or (buildDepError "monad-control"))
-          (hsPkgs."monad-loops" or (buildDepError "monad-loops"))
+          (hsPkgs."extra" or (buildDepError "extra"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."lens" or (buildDepError "lens"))
           (hsPkgs."mmorph" or (buildDepError "mmorph"))
-          (hsPkgs."mtl" or (buildDepError "mtl"))
-          (hsPkgs."o-clock" or (buildDepError "o-clock"))
-          (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."moo" or (buildDepError "moo"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."th-utilities" or (buildDepError "th-utilities"))
           (hsPkgs."transformers" or (buildDepError "transformers"))
-          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
-          (hsPkgs."universum" or (buildDepError "universum"))
-          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
-          (hsPkgs."vector" or (buildDepError "vector"))
-          (hsPkgs."yaml" or (buildDepError "yaml"))
-          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs."unix" or (buildDepError "unix"));
+          (hsPkgs."tree-diff" or (buildDepError "tree-diff"))
+          (hsPkgs."typerep-map" or (buildDepError "typerep-map"))
+          ];
         buildable = true;
+        };
+      tests = {
+        "goblin-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."goblins" or (buildDepError "goblins"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            ];
+          buildable = true;
+          };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/log-warper";
-      rev = "16246d4fbf16da7984f2a4b6c42f2ed5098182e4";
-      sha256 = "11vw6h3lshhwrjbxni6z0jr6w9x2x338rv6p2b4b0rgr650pv2a9";
+      url = "https://github.com/input-output-hk/goblins";
+      rev = "26d35ad52fe9ade3391532dbfeb2f416f07650bc";
+      sha256 = "17p5x0hj6c67jkdqx0cysqlwq2zs2l87azihn1alzajy9ak6ii0b";
       });
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { checktvarinvariant = false; };
     package = {
@@ -13,24 +52,26 @@
       synopsis = "Type classes for concurrency with STM, ST and timing";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.async)
-          (hsPkgs.bytestring)
-          (hsPkgs.mtl)
-          (hsPkgs.stm)
-          (hsPkgs.time)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."time" or (buildDepError "time"))
           ];
+        buildable = true;
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
-      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
+      rev = "2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3";
+      sha256 = "08f0078kra48cfwb0sz0fk7vfh966jjh2np5yjqrszhh16z0hw5r";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { disable-observables = false; performance-test-queue = false; };
     package = {
@@ -13,80 +52,83 @@
       synopsis = "logging, benchmarking and monitoring framework";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.aeson)
-          (hsPkgs.array)
-          (hsPkgs.async)
-          (hsPkgs.async-timer)
-          (hsPkgs.attoparsec)
-          (hsPkgs.auto-update)
-          (hsPkgs.base64-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.clock)
-          (hsPkgs.containers)
-          (hsPkgs.contravariant)
-          (hsPkgs.directory)
-          (hsPkgs.filepath)
-          (hsPkgs.katip)
-          (hsPkgs.lens)
-          (hsPkgs.mtl)
-          (hsPkgs.safe)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.scientific)
-          (hsPkgs.stm)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
-          (hsPkgs.yaml)
-          (hsPkgs.libyaml)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."async-timer" or (buildDepError "async-timer"))
+          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+          (hsPkgs."auto-update" or (buildDepError "auto-update"))
+          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."clock" or (buildDepError "clock"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."contravariant" or (buildDepError "contravariant"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."katip" or (buildDepError "katip"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."safe" or (buildDepError "safe"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
+          (hsPkgs."libyaml" or (buildDepError "libyaml"))
           ] ++ (if system.isWindows
-          then [ (hsPkgs.Win32) ]
-          else [ (hsPkgs.unix) ]);
+          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
+          else [ (hsPkgs."unix" or (buildDepError "unix")) ]);
+        buildable = true;
         };
       tests = {
         "tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.iohk-monitoring)
-            (hsPkgs.aeson)
-            (hsPkgs.array)
-            (hsPkgs.async)
-            (hsPkgs.bytestring)
-            (hsPkgs.clock)
-            (hsPkgs.containers)
-            (hsPkgs.directory)
-            (hsPkgs.filepath)
-            (hsPkgs.mtl)
-            (hsPkgs.process)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.random)
-            (hsPkgs.semigroups)
-            (hsPkgs.split)
-            (hsPkgs.stm)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.temporary)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.time-units)
-            (hsPkgs.transformers)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.vector)
-            (hsPkgs.void)
-            (hsPkgs.yaml)
-            (hsPkgs.libyaml)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."array" or (buildDepError "array"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."clock" or (buildDepError "clock"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."semigroups" or (buildDepError "semigroups"))
+            (hsPkgs."split" or (buildDepError "split"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."vector" or (buildDepError "vector"))
+            (hsPkgs."void" or (buildDepError "void"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            (hsPkgs."libyaml" or (buildDepError "libyaml"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/kademlia.nix
+++ b/nix/.stack.nix/kademlia.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,74 +52,78 @@
       synopsis = "An implementation of the Kademlia DHT Protocol";
       description = "\nA haskell implementation of the Kademlia distributed hashtable, an efficient\nway to store and lookup values distributed over a P2P network.\n\nThe implementation is based on the paper\n/Kademlia: A Peer-to-peer Information System Based on the XOR Metric/:\n<http://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf>\nby Petar Maymounkov and David Mazières.\n\nThis library aims to be very simple and pleasant to use, with the downside of\ndeciding some of the implementation details, like timeout intervals and\nk-bucket size, for the user.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.containers)
-          (hsPkgs.extra)
-          (hsPkgs.memory)
-          (hsPkgs.MonadRandom)
-          (hsPkgs.mtl)
-          (hsPkgs.network)
-          (hsPkgs.random)
-          (hsPkgs.random-shuffle)
-          (hsPkgs.stm)
-          (hsPkgs.time)
-          (hsPkgs.transformers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.contravariant)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."extra" or (buildDepError "extra"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."MonadRandom" or (buildDepError "MonadRandom"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."random-shuffle" or (buildDepError "random-shuffle"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."contravariant" or (buildDepError "contravariant"))
           ];
+        buildable = true;
         };
       exes = {
         "discovery-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.containers)
-            (hsPkgs.data-default)
-            (hsPkgs.extra)
-            (hsPkgs.kademlia)
-            (hsPkgs.MonadRandom)
-            (hsPkgs.mtl)
-            (hsPkgs.network)
-            (hsPkgs.random)
-            (hsPkgs.random-shuffle)
-            (hsPkgs.transformers)
-            (hsPkgs.transformers-compat)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."extra" or (buildDepError "extra"))
+            (hsPkgs."kademlia" or (buildDepError "kademlia"))
+            (hsPkgs."MonadRandom" or (buildDepError "MonadRandom"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."random-shuffle" or (buildDepError "random-shuffle"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."transformers-compat" or (buildDepError "transformers-compat"))
             ];
+          buildable = true;
           };
         };
       tests = {
         "library-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.containers)
-            (hsPkgs.data-default)
-            (hsPkgs.errors)
-            (hsPkgs.extra)
-            (hsPkgs.HUnit)
-            (hsPkgs.kademlia)
-            (hsPkgs.MonadRandom)
-            (hsPkgs.mtl)
-            (hsPkgs.network)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.random)
-            (hsPkgs.random-shuffle)
-            (hsPkgs.stm)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.time)
-            (hsPkgs.transformers)
-            (hsPkgs.transformers-compat)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."errors" or (buildDepError "errors"))
+            (hsPkgs."extra" or (buildDepError "extra"))
+            (hsPkgs."HUnit" or (buildDepError "HUnit"))
+            (hsPkgs."kademlia" or (buildDepError "kademlia"))
+            (hsPkgs."MonadRandom" or (buildDepError "MonadRandom"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."random-shuffle" or (buildDepError "random-shuffle"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."transformers-compat" or (buildDepError "transformers-compat"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { ipv6 = false; };
     package = {
@@ -13,57 +52,60 @@
       synopsis = "Multiplexing library";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.typed-protocols)
-          (hsPkgs.io-sim-classes)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.array)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.cborg)
-          (hsPkgs.network)
-          (hsPkgs.process)
-          (hsPkgs.time)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."time" or (buildDepError "time"))
           ];
+        buildable = true;
         };
       tests = {
         "test-network-mux" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.typed-protocols)
-            (hsPkgs.typed-protocols-cbor)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.io-sim)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.array)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.cborg)
-            (hsPkgs.containers)
-            (hsPkgs.hashable)
-            (hsPkgs.network)
-            (hsPkgs.process)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.splitmix)
-            (hsPkgs.serialise)
-            (hsPkgs.stm)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.time)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."array" or (buildDepError "array"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hashable" or (buildDepError "hashable"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."splitmix" or (buildDepError "splitmix"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
-      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
+      rev = "2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3";
+      sha256 = "08f0078kra48cfwb0sz0fk7vfh966jjh2np5yjqrszhh16z0hw5r";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-transport-inmemory.nix
+++ b/nix/.stack.nix/network-transport-inmemory.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,34 +52,38 @@
       synopsis = "In-memory instantiation of Network.Transport";
       description = "This is a transport implementation that could be used for local\ncommunication in the same address space (i.e. one process).\n\nIt could be used either for testing purposes or for local\ncommunication that require the network-transport semantics.\n\nNB: network-tranpsport-inmemory does not support cross-transport\ncommunication. All endpoints that want to comminicate should be\ncreated using the same transport.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.network-transport)
-          (hsPkgs.data-accessor)
-          (hsPkgs.bytestring)
-          (hsPkgs.containers)
-          (hsPkgs.stm)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."network-transport" or (buildDepError "network-transport"))
+          (hsPkgs."data-accessor" or (buildDepError "data-accessor"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."stm" or (buildDepError "stm"))
           ];
+        buildable = true;
         };
       tests = {
         "TestMulticastInMemory" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.network-transport-inmemory)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-tests)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."network-transport-inmemory" or (buildDepError "network-transport-inmemory"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-tests" or (buildDepError "network-transport-tests"))
             ];
+          buildable = false;
           };
         "TestInMemory" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.network-transport-inmemory)
-            (hsPkgs.network-transport-tests)
-            (hsPkgs.network-transport)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."network-transport-inmemory" or (buildDepError "network-transport-inmemory"))
+            (hsPkgs."network-transport-tests" or (buildDepError "network-transport-tests"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/network-transport-tcp.nix
+++ b/nix/.stack.nix/network-transport-tcp.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { use-mock-network = false; };
     package = {
@@ -13,49 +52,53 @@
       synopsis = "TCP instantiation of Network.Transport";
       description = "TCP instantiation of Network.Transport";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.network-transport)
-          (hsPkgs.data-accessor)
-          (hsPkgs.containers)
-          (hsPkgs.bytestring)
-          (hsPkgs.network)
-          (hsPkgs.uuid)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."network-transport" or (buildDepError "network-transport"))
+          (hsPkgs."data-accessor" or (buildDepError "data-accessor"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."uuid" or (buildDepError "uuid"))
           ];
+        buildable = true;
         };
       tests = {
         "TestTCP" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.network-transport-tests)
-            (hsPkgs.network)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-tcp)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."network-transport-tests" or (buildDepError "network-transport-tests"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
             ];
+          buildable = true;
           };
         "TestQC" = {
           depends = (pkgs.lib).optionals (flags.use-mock-network) [
-            (hsPkgs.base)
-            (hsPkgs.test-framework)
-            (hsPkgs.test-framework-quickcheck2)
-            (hsPkgs.test-framework-hunit)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.HUnit)
-            (hsPkgs.network-transport)
-            (hsPkgs.network-transport-tcp)
-            (hsPkgs.containers)
-            (hsPkgs.bytestring)
-            (hsPkgs.pretty)
-            (hsPkgs.data-accessor)
-            (hsPkgs.data-accessor-transformers)
-            (hsPkgs.mtl)
-            (hsPkgs.transformers)
-            (hsPkgs.lockfree-queue)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."test-framework" or (buildDepError "test-framework"))
+            (hsPkgs."test-framework-quickcheck2" or (buildDepError "test-framework-quickcheck2"))
+            (hsPkgs."test-framework-hunit" or (buildDepError "test-framework-hunit"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."HUnit" or (buildDepError "HUnit"))
+            (hsPkgs."network-transport" or (buildDepError "network-transport"))
+            (hsPkgs."network-transport-tcp" or (buildDepError "network-transport-tcp"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."pretty" or (buildDepError "pretty"))
+            (hsPkgs."data-accessor" or (buildDepError "data-accessor"))
+            (hsPkgs."data-accessor-transformers" or (buildDepError "data-accessor-transformers"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."lockfree-queue" or (buildDepError "lockfree-queue"))
             ];
+          buildable = if flags.use-mock-network then true else false;
           };
         };
       };

--- a/nix/.stack.nix/network-transport.nix
+++ b/nix/.stack.nix/network-transport.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,18 +52,20 @@
       synopsis = "Network abstraction layer";
       description = "\"Network.Transport\" is a Network Abstraction Layer which provides\nthe following high-level concepts:\n\n* Nodes in the network are represented by 'EndPoint's. These are\nheavyweight stateful objects.\n\n* Each 'EndPoint' has an 'EndPointAddress'.\n\n* Connections can be established from one 'EndPoint' to another\nusing the 'EndPointAddress' of the remote end.\n\n* The 'EndPointAddress' can be serialised and sent over the\nnetwork, where as 'EndPoint's and connections cannot.\n\n* Connections between 'EndPoint's are unidirectional and lightweight.\n\n* Outgoing messages are sent via a 'Connection' object that\nrepresents the sending end of the connection.\n\n* Incoming messages for /all/ of the incoming connections on\nan 'EndPoint' are collected via a shared receive queue.\n\n* In addition to incoming messages, 'EndPoint's are notified of\nother 'Event's such as new connections or broken connections.\n\nThis design was heavily influenced by the design of the Common\nCommunication Interface\n(<http://www.olcf.ornl.gov/center-projects/common-communication-interface>).\nImportant design goals are:\n\n* Connections should be lightweight: it should be no problem to\ncreate thousands of connections between endpoints.\n\n* Error handling is explicit: every function declares as part of\nits type which errors it can return (no exceptions are thrown)\n\n* Error handling is \"abstract\": errors that originate from\nimplementation specific problems (such as \"no more sockets\" in\nthe TCP implementation) get mapped to generic errors\n(\"insufficient resources\") at the Transport level.\n\nThis package provides the generic interface only; you will\nprobably also want to install at least one transport\nimplementation (network-transport-*).";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.hashable)
-          (hsPkgs.transformers)
-          (hsPkgs.deepseq)
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "7.6") (hsPkgs.ghc-prim);
-        libs = (pkgs.lib).optional (system.isWindows) (pkgs."ws2_32");
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "7.6") (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"));
+        libs = (pkgs.lib).optional (system.isWindows) (pkgs."ws2_32" or (sysDepError "ws2_32"));
+        buildable = true;
         };
       };
     } // {

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -1,6 +1,45 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = { checktvarinvariant = false; };
+    flags = {};
     package = {
       specVersion = "1.10";
       identifier = { name = "ouroboros-consensus"; version = "0.1.0.0"; };
@@ -13,163 +52,185 @@
       synopsis = "Consensus layer for the Ouroboros blockchain protocol";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.ouroboros-network)
-          (hsPkgs.network-mux)
-          (hsPkgs.typed-protocols)
-          (hsPkgs.typed-protocols-cbor)
-          (hsPkgs.io-sim-classes)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.cardano-ledger-test)
-          (hsPkgs.bifunctors)
-          (hsPkgs.bimap)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-crypto-class)
-          (hsPkgs.cardano-crypto-wrapper)
-          (hsPkgs.cardano-ledger)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cborg)
-          (hsPkgs.constraints)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.deepseq)
-          (hsPkgs.directory)
-          (hsPkgs.filepath)
-          (hsPkgs.fingertree)
-          (hsPkgs.formatting)
-          (hsPkgs.memory)
-          (hsPkgs.mmorph)
-          (hsPkgs.mtl)
-          (hsPkgs.network)
-          (hsPkgs.pipes)
-          (hsPkgs.reflection)
-          (hsPkgs.serialise)
-          (hsPkgs.stm)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.transformers)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+          (hsPkgs."network-mux" or (buildDepError "network-mux"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+          (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."bifunctors" or (buildDepError "bifunctors"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
+          (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."constraints" or (buildDepError "constraints"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."fingertree" or (buildDepError "fingertree"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."pipes" or (buildDepError "pipes"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ] ++ (if system.isWindows
-          then [ (hsPkgs.Win32) ]
-          else [ (hsPkgs.unix) ]);
+          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
+          else [ (hsPkgs."unix" or (buildDepError "unix")) ]);
+        buildable = true;
         };
       exes = {
         "byron-db-converter" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.directory)
-            (hsPkgs.mtl)
-            (hsPkgs.optparse-applicative)
-            (hsPkgs.optparse-generic)
-            (hsPkgs.ouroboros-consensus)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.reflection)
-            (hsPkgs.resourcet)
-            (hsPkgs.streaming)
-            (hsPkgs.text)
-            (hsPkgs.time)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."optparse-generic" or (buildDepError "optparse-generic"))
+            (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
+            (hsPkgs."resourcet" or (buildDepError "resourcet"))
+            (hsPkgs."streaming" or (buildDepError "streaming"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
+          buildable = true;
+          };
+        "analyse-db" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
+            ];
+          buildable = true;
           };
         };
       tests = {
         "test-consensus" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-crypto-class)
-            (hsPkgs.cardano-crypto-wrapper)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.cardano-ledger-test)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.typed-protocols)
-            (hsPkgs.network-mux)
-            (hsPkgs.ouroboros-network)
-            (hsPkgs.ouroboros-consensus)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.io-sim)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.cryptonite)
-            (hsPkgs.deepseq)
-            (hsPkgs.fgl)
-            (hsPkgs.fingertree)
-            (hsPkgs.generics-sop)
-            (hsPkgs.graphviz)
-            (hsPkgs.mtl)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-state-machine)
-            (hsPkgs.random)
-            (hsPkgs.reflection)
-            (hsPkgs.serialise)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.tree-diff)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-crypto-test" or (buildDepError "cardano-crypto-test"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-ledger-test" or (buildDepError "cardano-ledger-test"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+            (hsPkgs."network-mux" or (buildDepError "network-mux"))
+            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."fgl" or (buildDepError "fgl"))
+            (hsPkgs."fingertree" or (buildDepError "fingertree"))
+            (hsPkgs."generics-sop" or (buildDepError "generics-sop"))
+            (hsPkgs."graphviz" or (buildDepError "graphviz"))
+            (hsPkgs."hedgehog-quickcheck" or (buildDepError "hedgehog-quickcheck"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-state-machine" or (buildDepError "quickcheck-state-machine"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."tree-diff" or (buildDepError "tree-diff"))
             ];
+          buildable = true;
           };
         "test-storage" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-crypto-class)
-            (hsPkgs.cardano-ledger)
-            (hsPkgs.cardano-ledger-test)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.ouroboros-network)
-            (hsPkgs.ouroboros-network-testing)
-            (hsPkgs.ouroboros-consensus)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.io-sim)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.bifunctors)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.cereal)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.deepseq)
-            (hsPkgs.directory)
-            (hsPkgs.fingertree)
-            (hsPkgs.generics-sop)
-            (hsPkgs.mtl)
-            (hsPkgs.pretty-show)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-state-machine)
-            (hsPkgs.random)
-            (hsPkgs.reflection)
-            (hsPkgs.serialise)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.temporary)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.transformers)
-            (hsPkgs.tree-diff)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-ledger-test" or (buildDepError "cardano-ledger-test"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."ouroboros-network-testing" or (buildDepError "ouroboros-network-testing"))
+            (hsPkgs."ouroboros-consensus" or (buildDepError "ouroboros-consensus"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."bifunctors" or (buildDepError "bifunctors"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."cereal" or (buildDepError "cereal"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."fingertree" or (buildDepError "fingertree"))
+            (hsPkgs."generics-sop" or (buildDepError "generics-sop"))
+            (hsPkgs."hashable" or (buildDepError "hashable"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-state-machine" or (buildDepError "quickcheck-state-machine"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."reflection" or (buildDepError "reflection"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."tree-diff" or (buildDepError "tree-diff"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
-      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
+      rev = "2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3";
+      sha256 = "08f0078kra48cfwb0sz0fk7vfh966jjh2np5yjqrszhh16z0hw5r";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { ipv6 = false; cddl = false; };
     package = {
@@ -13,127 +52,132 @@
       synopsis = "A networking layer for the Ouroboros blockchain protocol";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.network-mux)
-          (hsPkgs.typed-protocols)
-          (hsPkgs.typed-protocols-cbor)
-          (hsPkgs.io-sim-classes)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.async)
-          (hsPkgs.binary)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cborg)
-          (hsPkgs.containers)
-          (hsPkgs.dns)
-          (hsPkgs.fingertree)
-          (hsPkgs.iproute)
-          (hsPkgs.network)
-          (hsPkgs.serialise)
-          (hsPkgs.stm)
-          (hsPkgs.time)
-          (hsPkgs.hashable)
-          (hsPkgs.text)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."network-mux" or (buildDepError "network-mux"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
+          (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."binary" or (buildDepError "binary"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."dns" or (buildDepError "dns"))
+          (hsPkgs."fingertree" or (buildDepError "fingertree"))
+          (hsPkgs."iproute" or (buildDepError "iproute"))
+          (hsPkgs."network" or (buildDepError "network"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."text" or (buildDepError "text"))
           ];
+        buildable = true;
         };
       exes = {
         "demo-chain-sync" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.async)
-            (hsPkgs.bytestring)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.directory)
-            (hsPkgs.network-mux)
-            (hsPkgs.network)
-            (hsPkgs.ouroboros-network)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.random)
-            (hsPkgs.serialise)
-            (hsPkgs.splitmix)
-            (hsPkgs.stm)
-            (hsPkgs.typed-protocols-cbor)
-            (hsPkgs.typed-protocols)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."network-mux" or (buildDepError "network-mux"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."splitmix" or (buildDepError "splitmix"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
             ];
+          buildable = true;
           };
         };
       tests = {
         "test-network" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.array)
-            (hsPkgs.async)
-            (hsPkgs.binary)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cborg)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.directory)
-            (hsPkgs.dns)
-            (hsPkgs.fingertree)
-            (hsPkgs.hashable)
-            (hsPkgs.io-sim)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.iproute)
-            (hsPkgs.mtl)
-            (hsPkgs.network-mux)
-            (hsPkgs.network)
-            (hsPkgs.ouroboros-network-testing)
-            (hsPkgs.pipes)
-            (hsPkgs.process)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.serialise)
-            (hsPkgs.splitmix)
-            (hsPkgs.stm)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.tasty)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.typed-protocols-cbor)
-            (hsPkgs.typed-protocols)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."array" or (buildDepError "array"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."binary" or (buildDepError "binary"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."dns" or (buildDepError "dns"))
+            (hsPkgs."fingertree" or (buildDepError "fingertree"))
+            (hsPkgs."hashable" or (buildDepError "hashable"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."iproute" or (buildDepError "iproute"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."network-mux" or (buildDepError "network-mux"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."ouroboros-network-testing" or (buildDepError "ouroboros-network-testing"))
+            (hsPkgs."pipes" or (buildDepError "pipes"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."splitmix" or (buildDepError "splitmix"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
             ];
+          buildable = true;
           };
         "cddl" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cborg)
-            (hsPkgs.containers)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.fingertree)
-            (hsPkgs.hashable)
-            (hsPkgs.io-sim)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.network-mux)
-            (hsPkgs.pipes)
-            (hsPkgs.process-extras)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.serialise)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.text)
-            (hsPkgs.typed-protocols-cbor)
-            (hsPkgs.typed-protocols)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."fingertree" or (buildDepError "fingertree"))
+            (hsPkgs."hashable" or (buildDepError "hashable"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."network-mux" or (buildDepError "network-mux"))
+            (hsPkgs."pipes" or (buildDepError "pipes"))
+            (hsPkgs."process-extras" or (buildDepError "process-extras"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."typed-protocols-cbor" or (buildDepError "typed-protocols-cbor"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
             ];
+          buildable = if !flags.cddl then false else true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
-      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
+      rev = "2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3";
+      sha256 = "08f0078kra48cfwb0sz0fk7vfh966jjh2np5yjqrszhh16z0hw5r";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/serokell-util.nix
+++ b/nix/.stack.nix/serokell-util.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,58 +52,61 @@
       synopsis = "General-purpose functions by Serokell";
       description = "Serokell-util is a library consisting of functions, which\nare not included in standard libraries, but are useful for\nmultiple projects. This library was created when it was\nfound that in new projects we need to use some utility\nfunctions from existing projects and don't want to\ncopy-paste them.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.ansi-terminal)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.base64-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.clock)
-          (hsPkgs.deepseq)
-          (hsPkgs.exceptions)
-          (hsPkgs.fmt)
-          (hsPkgs.formatting)
-          (hsPkgs.hashable)
-          (hsPkgs.microlens)
-          (hsPkgs.microlens-mtl)
-          (hsPkgs.mtl)
-          (hsPkgs.o-clock)
-          (hsPkgs.megaparsec)
-          (hsPkgs.process)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.scientific)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.th-lift-instances)
-          (hsPkgs.transformers)
-          (hsPkgs.universum)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."ansi-terminal" or (buildDepError "ansi-terminal"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."clock" or (buildDepError "clock"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."fmt" or (buildDepError "fmt"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."microlens" or (buildDepError "microlens"))
+          (hsPkgs."microlens-mtl" or (buildDepError "microlens-mtl"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."o-clock" or (buildDepError "o-clock"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."th-lift-instances" or (buildDepError "th-lift-instances"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."universum" or (buildDepError "universum"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       tests = {
         "serokell-test" = {
           depends = [
-            (hsPkgs.aeson)
-            (hsPkgs.base)
-            (hsPkgs.extra)
-            (hsPkgs.hspec)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.scientific)
-            (hsPkgs.serokell-util)
-            (hsPkgs.universum)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.vector)
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."extra" or (buildDepError "extra"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."scientific" or (buildDepError "scientific"))
+            (hsPkgs."serokell-util" or (buildDepError "serokell-util"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."vector" or (buildDepError "vector"))
             ];
           build-tools = [
-            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))
             ];
+          buildable = true;
           };
         };
       };

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -39,17 +39,17 @@ let
       '';
 in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { development = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "rocksdb-haskell-ng"; version = "0.0.0"; };
+      identifier = { name = "small-steps"; version = "0.1.0.0"; };
       license = "BSD-3-Clause";
       copyright = "";
-      maintainer = "";
-      author = "";
-      homepage = "";
+      maintainer = "formal.methods@iohk.io";
+      author = "IOHK Formal Methods Team";
+      homepage = "https://github.com/input-output-hk/cardano-chain";
       url = "";
-      synopsis = "";
+      synopsis = "Small step semantics";
       description = "";
       buildType = "Simple";
       isLocal = true;
@@ -58,39 +58,49 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."free" or (buildDepError "free"))
+          (hsPkgs."goblins" or (buildDepError "goblins"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
           ];
-        libs = [ (pkgs."rocksdb" or (sysDepError "rocksdb")) ];
         buildable = true;
         };
       tests = {
-        "test" = {
+        "doctests" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."rocksdb-haskell-ng" or (buildDepError "rocksdb-haskell-ng"))
-            (hsPkgs."hspec" or (buildDepError "hspec"))
-            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
-            (hsPkgs."temporary" or (buildDepError "temporary"))
-            (hsPkgs."directory" or (buildDepError "directory"))
-            (hsPkgs."filepath" or (buildDepError "filepath"))
-            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."free" or (buildDepError "free"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."sequence" or (buildDepError "sequence"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."doctest" or (buildDepError "doctest"))
+            (hsPkgs."small-steps" or (buildDepError "small-steps"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.doctest-discover or (pkgs.buildPackages.doctest-discover or (buildToolDepError "doctest-discover")))
             ];
           buildable = true;
           };
-        };
-      benchmarks = {
-        "speed" = {
+        "examples" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."rocksdb-haskell-ng" or (buildDepError "rocksdb-haskell-ng"))
-            (hsPkgs."criterion" or (buildDepError "criterion"))
-            (hsPkgs."hspec" or (buildDepError "hspec"))
-            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
-            (hsPkgs."temporary" or (buildDepError "temporary"))
-            (hsPkgs."directory" or (buildDepError "directory"))
-            (hsPkgs."filepath" or (buildDepError "filepath"))
-            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-expected-failure" or (buildDepError "tasty-expected-failure"))
+            (hsPkgs."small-steps" or (buildDepError "small-steps"))
             ];
           buildable = true;
           };
@@ -98,8 +108,9 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/rocksdb-haskell-ng";
-      rev = "49f501a082d745f3b880677220a29cafaa181452";
-      sha256 = "02jvri8ik8jgrxwa6qmh3xcwqvm4s27iv3sxpjpny79nlhlxvfzp";
+      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      rev = "0d7e670952657c23a6486bfa15e9d10166351986";
+      sha256 = "1anikzb6ypi8zz973h7fap9djjbrqvw5mhqrch6av05xqkaqx3jv";
       });
+    postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/transformers-lift.nix
+++ b/nix/.stack.nix/transformers-lift.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,14 +52,16 @@
       synopsis = "Ad-hoc type classes for lifting";
       description = "This simple and lightweight library provides type classes\nfor lifting monad transformer operations.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.transformers)
-          (hsPkgs.writer-cps-transformers)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."writer-cps-transformers" or (buildDepError "writer-cps-transformers"))
           ];
+        buildable = true;
         };
       };
     } // {

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,39 +52,42 @@
       synopsis = "";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cborg)
-          (hsPkgs.serialise)
-          (hsPkgs.io-sim-classes)
-          (hsPkgs.typed-protocols)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
           ];
+        buildable = true;
         };
       tests = {
         "test-typed-protocols-cbor" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cborg)
-            (hsPkgs.serialise)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.typed-protocols)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
-      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
+      rev = "2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3";
+      sha256 = "08f0078kra48cfwb0sz0fk7vfh966jjh2np5yjqrszhh16z0hw5r";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,38 +52,41 @@
       synopsis = "A framework for strongly typed protocols";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.io-sim-classes)
-          (hsPkgs.bytestring)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.time)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."time" or (buildDepError "time"))
           ];
+        buildable = true;
         };
       tests = {
         "test-protocols" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.io-sim-classes)
-            (hsPkgs.io-sim)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.time)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."io-sim-classes" or (buildDepError "io-sim-classes"))
+            (hsPkgs."io-sim" or (buildDepError "io-sim"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
+          buildable = true;
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d3e71facd53da4a2c72e4947f551ddeac45fba41";
-      sha256 = "1xgblkjpngkad932krgz04i9ai9zjqn151dr4m2mxr7qxqkzrpxn";
+      rev = "2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3";
+      sha256 = "08f0078kra48cfwb0sz0fk7vfh966jjh2np5yjqrszhh16z0hw5r";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/universum.nix
+++ b/nix/.stack.nix/universum.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,57 +52,66 @@
       synopsis = "Custom prelude used in Serokell";
       description = "See README.md file for more details.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.containers)
-          (hsPkgs.deepseq)
-          (hsPkgs.ghc-prim)
-          (hsPkgs.hashable)
-          (hsPkgs.microlens)
-          (hsPkgs.microlens-mtl)
-          (hsPkgs.mtl)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.stm)
-          (hsPkgs.text)
-          (hsPkgs.transformers)
-          (hsPkgs.type-operators)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.utf8-string)
-          (hsPkgs.vector)
-          (hsPkgs.formatting)
-          (hsPkgs.fmt)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."microlens" or (buildDepError "microlens"))
+          (hsPkgs."microlens-mtl" or (buildDepError "microlens-mtl"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."type-operators" or (buildDepError "type-operators"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."utf8-string" or (buildDepError "utf8-string"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."fmt" or (buildDepError "fmt"))
           ];
+        buildable = true;
         };
       tests = {
         "universum-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.universum)
-            (hsPkgs.bytestring)
-            (hsPkgs.text)
-            (hsPkgs.utf8-string)
-            (hsPkgs.hedgehog)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hedgehog)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."utf8-string" or (buildDepError "utf8-string"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
             ];
+          buildable = true;
           };
         "universum-doctest" = {
-          depends = [ (hsPkgs.base) (hsPkgs.doctest) (hsPkgs.Glob) ];
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."doctest" or (buildDepError "doctest"))
+            (hsPkgs."Glob" or (buildDepError "Glob"))
+            ];
+          buildable = true;
           };
         };
       benchmarks = {
         "universum-benchmark" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.universum)
-            (hsPkgs.containers)
-            (hsPkgs.gauge)
-            (hsPkgs.unordered-containers)
-            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).eq "7.10.3") (hsPkgs.semigroups);
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."universum" or (buildDepError "universum"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."gauge" or (buildDepError "gauge"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).eq "7.10.3") (hsPkgs."semigroups" or (buildDepError "semigroups"));
+          buildable = true;
           };
         };
       };

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "999a030035a7cb55d9740a508a9c6b857dbabdf6",
-  "date": "2019-08-20T13:42:19+00:00",
-  "sha256": "07fq8d98c8pw141rgfr7x998sghgdx9mpf5s1db160z2cp8kc7p2",
+  "rev": "7292b0a958d58aaeea21e3b20b597e947a2151e0",
+  "sha256": "1y6iml1l28b96xsny5fvx308mymrwalsms7dn10lwl56zmf3r3zc",
+  "date": "2019-09-23T13:42:19+00:00",
   "fetchSubmodules": false
 }

--- a/src/exec/DB.hs
+++ b/src/exec/DB.hs
@@ -8,7 +8,7 @@ module DB
   ) where
 
 import           Control.Exception                         (bracket)
-import           Control.Tracer                            (Tracer)
+import           Control.Tracer                            (Tracer, nullTracer)
 import qualified Data.Reflection                           as Reflection (given)
 import           Data.Time.Clock                           (secondsToDiffTime)
 import qualified System.Directory                          (createDirectoryIfMissing)
@@ -124,6 +124,7 @@ withDB dbOptions dbTracer indexTracer rr nodeConfig extLedgerState k = do
         , cdbGenesis = pure extLedgerState
 
         , cdbTracer = dbTracer
+        , cdbTraceLedger = nullTracer
         , cdbRegistry = rr
         , cdbGcDelay = secondsToDiffTime 20
         }

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -282,6 +282,13 @@ cliParser = ByronProxyOptions
               , Opt.metavar "FILEPATH"
               , Opt.help "Path to a YAML file containing the network policies"
               ]
+      ncoCheckPeerHost <-
+          (not <$>) .
+          Opt.switch $
+          mconcat
+              [ Opt.long "disable-peer-host-check"
+              , Opt.help "DANGER: disable the peer host address consistency check. Makes your node vulnerable"
+              ]
       ncoExternalAddress <- Opt.optional $ CSL.externalNetworkAddressOption Nothing
       ncoBindAddress <- Opt.optional $ CSL.listenNetworkAddressOption Nothing
       pure $ CSL.NetworkConfigOpts
@@ -292,6 +299,7 @@ cliParser = ByronProxyOptions
         , CSL.ncoPolicies = ncoPolicies
         , CSL.ncoExternalAddress = ncoExternalAddress
         , CSL.ncoBindAddress = ncoBindAddress
+        , CSL.ncoCheckPeerHost = ncoCheckPeerHost
         }
 
   dashconcat :: [String] -> String

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -80,7 +80,7 @@ import Ouroboros.Consensus.Node (getMempool)
 import Ouroboros.Consensus.Node.ProtocolInfo.Abstract (ProtocolInfo (..))
 import Ouroboros.Consensus.Node.ProtocolInfo.Byron (PBftSignatureThreshold (..),
            protocolInfoByron)
-import Ouroboros.Network.NodeToNode (IPSubscriptionTarget (..), withServer, ipSubscriptionWorker)
+import Ouroboros.Network.NodeToNode (IPSubscriptionTarget (..), LocalAddresses (..), withServer, ipSubscriptionWorker)
 import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry (withRegistry)
 import Ouroboros.Network.Block (BlockNo (..), Point (..))
@@ -350,8 +350,10 @@ runShelleyClient producerAddrs _ ctable iversions = do
     nullTracer
     Shelley.mkPeer
     ctable
-    (Just (Network.SockAddrInet 0 0))
-    (Just (Network.SockAddrInet6 0 0 (0, 0, 0, 1) 0))
+    (LocalAddresses
+     (Just (Network.SockAddrInet 0 0))
+     (Just (Network.SockAddrInet6 0 0 (0, 0, 0, 1) 0))
+     Nothing)
     (const Nothing)
     (IPSubscriptionTarget {
          ispIps     = fmap Network.addrAddress sockAddrs

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Shelley where
 
@@ -13,11 +14,11 @@ import Cardano.Chain.UTxO.Validation ()
 import Crypto.Random (drgNew)
 import qualified Network.Socket as Socket
 
-import Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF(..))
+import Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF(..), Proxy(..))
 
 import Ouroboros.Byron.Proxy.Block (Block)
 import Ouroboros.Consensus.Block (BlockProtocol)
-import Ouroboros.Consensus.Protocol (NodeConfig, NodeState, protocolNetworkMagic)
+import Ouroboros.Consensus.Protocol (NodeConfig, NodeState)
 import Ouroboros.Consensus.Ledger.Byron (ByronGiven)
 import Ouroboros.Consensus.Ledger.Byron.Config (ByronConfig)
 import Ouroboros.Consensus.Mempool.Impl (MempoolCapacity (..))
@@ -78,7 +79,7 @@ versions
   :: ( ByronGiven )
   => NodeConfig (BlockProtocol (Block ByronConfig)) -> NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ()
   -> Versions NodeToNodeVersion DictVersion (NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ())
-versions conf = simpleSingletonVersions NodeToNodeV_1 (NodeToNodeVersionData (protocolNetworkMagic conf)) (DictVersion nodeToNodeCodecCBORTerm)
+versions conf = simpleSingletonVersions NodeToNodeV_1 (NodeToNodeVersionData (nodeNetworkMagic (Proxy @(Block ByronConfig)) conf)) (DictVersion nodeToNodeCodecCBORTerm)
 
 mkParams
   :: ( ByronGiven )

--- a/src/lib/Ouroboros/Byron/Proxy/Genesis/Convert.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Genesis/Convert.hs
@@ -63,11 +63,11 @@ convertProtocolMagicId pmid = Cardano.ProtocolMagicId (fromIntegral (CSL.unProto
 convertAvvmDistr :: CSL.GenesisAvvmBalances -> Cardano.GenesisAvvmBalances
 convertAvvmDistr = Cardano.GenesisAvvmBalances . Map.fromList . fmap convertPair . HashMap.toList . CSL.getGenesisAvvmBalances
   where
-  convertPair :: (CSL.RedeemPublicKey, CSL.Coin) -> (Cardano.RedeemVerificationKey, Cardano.Lovelace)
+  convertPair :: (CSL.RedeemPublicKey, CSL.Coin) -> (Cardano.CompactRedeemVerificationKey, Cardano.Lovelace)
   convertPair (pubkey, coin) = (convertRedeemPublicKey pubkey, convertCoin coin)
 
-convertRedeemPublicKey :: CSL.RedeemPublicKey -> Cardano.RedeemVerificationKey
-convertRedeemPublicKey (CSL.RedeemPublicKey pubkey) = Cardano.RedeemVerificationKey pubkey
+convertRedeemPublicKey :: CSL.RedeemPublicKey -> Cardano.CompactRedeemVerificationKey
+convertRedeemPublicKey (CSL.RedeemPublicKey pubkey) = Cardano.toCompactRedeemVerificationKey $ Cardano.RedeemVerificationKey pubkey
 
 convertHeavyDelegation :: CSL.GenesisDelegation -> Cardano.GenesisDelegation
 convertHeavyDelegation = Cardano.UnsafeGenesisDelegation . Map.fromList . fmap convertPair . HashMap.toList . CSL.unGenesisDelegation

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,14 +12,14 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 13e7ffbc142eb1b9d7266c8f5373d787acb65266
+    commit: 5c575d46afbfe333de0ccba70b084db8302abf42
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: a1de5b52c32255464564a6c5a8a9e474086e3875
+    commit: 181f69af290412abecefc07e1b26e77a453755ff
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -27,13 +27,13 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: b9bf62f2bab90539809bee13620fe7d29b35928d
+    commit: ad19158c7599bc5d50fe7cb0111a1488a139a381
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/cardano-shell
-    commit: 8b8437fa2c0cd7e0c1f0ee94ae1565dbcf5617d0
+    commit: 8abae427c44f0b447117f78e2c1f5006dac2edf8
     subdirs:
       - cardano-shell
 
@@ -41,7 +41,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: d3e71facd53da4a2c72e4947f551ddeac45fba41
+    commit: b7d3ef6c68169e5ce4396b26085a9cebc500f615
     subdirs:
       - ouroboros-consensus
       - ouroboros-network
@@ -71,7 +71,7 @@ extra-deps:
 
   # The parts of cardano-sl that are needed for the byron proxy.
   - git: https://github.com/input-output-hk/cardano-sl
-    commit: 4f8cbfc63a7c741108995469a08d70202dda3e0c
+    commit: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
     subdirs:
       - lib
       - binary

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: b7d3ef6c68169e5ce4396b26085a9cebc500f615
+    commit: 2441f25ee5a2da0fbf008f3e9a1b1fd4e57f1de3
     subdirs:
       - ouroboros-consensus
       - ouroboros-network
@@ -52,16 +52,16 @@ extra-deps:
 
   - bimap-0.4.0
   - binary-0.8.7.0
-  - time-units-1.0.0
-  - ekg-prometheus-adapter-0.1.0.4
-  - prometheus-2.1.1
   - containers-0.5.11.0
+  - ekg-prometheus-adapter-0.1.0.4
+  - generic-monoid-0.1.0.0
   - graphviz-2999.20.0.3@sha256:cde383c356bc41136ed53cd27e0800f46dbd2185600dd0de18d66d5c49739d94
+  - libsystemd-journal-1.4.4
+  - prometheus-2.1.1
   - quickcheck-state-machine-0.6.0@sha256:3e4f8df0f6b5d415e3c8840dc75034a63e37f56f5f8cfa1035ded16345235ac4
   - splitmix-0.0.2
-  - libsystemd-journal-1.4.4
   - tasty-hedgehog-1.0.0.1
-  - generic-monoid-0.1.0.0
+  - time-units-1.0.0
 
   # Windows only
   - Win32-2.5.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,9 +50,6 @@ extra-deps:
       - typed-protocols
       - typed-protocols-cbor
 
-  - git: https://github.com/well-typed/canonical-json
-    commit: ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f
-
   - bimap-0.4.0
   - binary-0.8.7.0
   - time-units-1.0.0


### PR DESCRIPTION
This:

1. Bumps dependencies to the version used in `cardano-node`,
2. Uses a bumped `cardano-sl` with https://github.com/input-output-hk/cardano-sl/pull/4247
3. Updates to changes in `cardano-ledger` and `ouroboros-network`
4. Adds new dependencies to facilitate the above.