### PR TITLE
Bump dependencies & protocol version fix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -196,97 +196,97 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: lib
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: util
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: util/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: infra/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: core
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: core/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: chain
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: chain/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: db/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
   subdir: networking
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -144,25 +144,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 181f69af290412abecefc07e1b26e77a453755ff
+  tag: ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 181f69af290412abecefc07e1b26e77a453755ff
+  tag: ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 181f69af290412abecefc07e1b26e77a453755ff
+  tag: ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 181f69af290412abecefc07e1b26e77a453755ff
+  tag: ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19
   subdir: crypto/test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -75,8 +75,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "181f69af290412abecefc07e1b26e77a453755ff";
-      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
+      rev = "ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19";
+      sha256 = "101fw5s0rsj0npc0ci6ianwhdsrnjgzpigmy03wi0ayif4s0rr7k";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -102,8 +102,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "181f69af290412abecefc07e1b26e77a453755ff";
-      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
+      rev = "ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19";
+      sha256 = "101fw5s0rsj0npc0ci6ianwhdsrnjgzpigmy03wi0ayif4s0rr7k";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -96,8 +96,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "181f69af290412abecefc07e1b26e77a453755ff";
-      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
+      rev = "ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19";
+      sha256 = "101fw5s0rsj0npc0ci6ianwhdsrnjgzpigmy03wi0ayif4s0rr7k";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -160,8 +160,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "181f69af290412abecefc07e1b26e77a453755ff";
-      sha256 = "05f3sz25jnxa45ycy4irx68spa0m39q79ryxjsz5ih877lf6p5gy";
+      rev = "ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19";
+      sha256 = "101fw5s0rsj0npc0ci6ianwhdsrnjgzpigmy03wi0ayif4s0rr7k";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-binary-test.nix
+++ b/nix/.stack.nix/cardano-sl-binary-test.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-binary.nix
+++ b/nix/.stack.nix/cardano-sl-binary.nix
@@ -127,8 +127,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-chain-test.nix
+++ b/nix/.stack.nix/cardano-sl-chain-test.nix
@@ -93,8 +93,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/chain/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-chain.nix
+++ b/nix/.stack.nix/cardano-sl-chain.nix
@@ -189,8 +189,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/chain; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-core-test.nix
+++ b/nix/.stack.nix/cardano-sl-core-test.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/core/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-core.nix
+++ b/nix/.stack.nix/cardano-sl-core.nix
@@ -151,8 +151,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-crypto-test.nix
+++ b/nix/.stack.nix/cardano-sl-crypto-test.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-crypto.nix
+++ b/nix/.stack.nix/cardano-sl-crypto.nix
@@ -124,8 +124,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-db-test.nix
+++ b/nix/.stack.nix/cardano-sl-db-test.nix
@@ -76,8 +76,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/db/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-db.nix
+++ b/nix/.stack.nix/cardano-sl-db.nix
@@ -131,8 +131,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/db; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-infra-test.nix
+++ b/nix/.stack.nix/cardano-sl-infra-test.nix
@@ -87,8 +87,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/infra/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-infra.nix
+++ b/nix/.stack.nix/cardano-sl-infra.nix
@@ -149,8 +149,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/infra; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-networking.nix
+++ b/nix/.stack.nix/cardano-sl-networking.nix
@@ -210,8 +210,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/networking; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-util-test.nix
+++ b/nix/.stack.nix/cardano-sl-util-test.nix
@@ -94,8 +94,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/util/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-util.nix
+++ b/nix/.stack.nix/cardano-sl-util.nix
@@ -148,8 +148,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/util; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl.nix
+++ b/nix/.stack.nix/cardano-sl.nix
@@ -244,8 +244,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0";
-      sha256 = "01aprnh4vzyhhy1izyygyywgghn3pr3pfa64870xpzyqkrk6sn2r";
+      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
+      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
       });
     postUnpack = "sourceRoot+=/lib; echo source root reset to \$sourceRoot";
     }

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "7292b0a958d58aaeea21e3b20b597e947a2151e0",
-  "sha256": "1y6iml1l28b96xsny5fvx308mymrwalsms7dn10lwl56zmf3r3zc",
-  "date": "2019-09-23T13:42:19+00:00",
+  "rev": "5f67c8d5b6f4e0c202c6c949d91ff1cb4d7050a3",
+  "date": "2019-10-31T11:59:21+00:00",
+  "sha256": "1ih0261yj4i5sb5ihwfqyrnfm836p3z5sm8qq6yhab16csxs373n",
   "fetchSubmodules": false
 }

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -515,7 +515,7 @@ main = do
         -- Thread registry is needed by ChainDB and by the network protocols.
         -- I assume it's supposed to be shared?
         ResourceRegistry.withRegistry $ \rr -> do
-          let protocolVersion = Cardano.ProtocolVersion 1 0 0
+          let protocolVersion = Cardano.ProtocolVersion 0 0 0
               softwareVersion = Cardano.SoftwareVersion
                 (Cardano.ApplicationName (fromString "cardano-byron-proxy")) 2
               protocolInfo = protocolInfoByron

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 181f69af290412abecefc07e1b26e77a453755ff
+    commit: ad96c9a1d3be469a7d4f10ee1c443cdb15a12b19
     subdirs:
       - cardano-ledger
       - cardano-ledger/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -68,7 +68,7 @@ extra-deps:
 
   # The parts of cardano-sl that are needed for the byron proxy.
   - git: https://github.com/input-output-hk/cardano-sl
-    commit: 2a5b5769799fd220e2ff6a6b09a1832d8e6f06c0
+    commit: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
     subdirs:
       - lib
       - binary


### PR DESCRIPTION
Note, that this additionally sets the initial protocol version to `0.0.0`:

https://github.com/input-output-hk/cardano-byron-proxy/pull/60/files#diff-b8fc4e99e5238081c35ea7b6f53b554bL518