### PR TITLE
Mainnet CI prerequisites, final round

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -312,7 +312,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/avieth/network-transport-tcp
-  tag: 2634e5e32178bb0456d800d133f8664321daa2ef
+  tag: 46f2942423d9ad3c81040565a9e9d5b9e08ddcc4
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -196,97 +196,97 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: lib
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: util
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: util/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: infra/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: core
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: core/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: chain
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: chain/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: db/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+  tag: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
   subdir: networking
 
 source-repository-package

--- a/nix/.stack.nix/cardano-sl-binary-test.nix
+++ b/nix/.stack.nix/cardano-sl-binary-test.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-binary.nix
+++ b/nix/.stack.nix/cardano-sl-binary.nix
@@ -127,8 +127,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-chain-test.nix
+++ b/nix/.stack.nix/cardano-sl-chain-test.nix
@@ -93,8 +93,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/chain/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-chain.nix
+++ b/nix/.stack.nix/cardano-sl-chain.nix
@@ -189,8 +189,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/chain; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-core-test.nix
+++ b/nix/.stack.nix/cardano-sl-core-test.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/core/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-core.nix
+++ b/nix/.stack.nix/cardano-sl-core.nix
@@ -151,8 +151,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-crypto-test.nix
+++ b/nix/.stack.nix/cardano-sl-crypto-test.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-crypto.nix
+++ b/nix/.stack.nix/cardano-sl-crypto.nix
@@ -124,8 +124,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-db-test.nix
+++ b/nix/.stack.nix/cardano-sl-db-test.nix
@@ -76,8 +76,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/db/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-db.nix
+++ b/nix/.stack.nix/cardano-sl-db.nix
@@ -131,8 +131,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/db; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-infra-test.nix
+++ b/nix/.stack.nix/cardano-sl-infra-test.nix
@@ -87,8 +87,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/infra/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-infra.nix
+++ b/nix/.stack.nix/cardano-sl-infra.nix
@@ -149,8 +149,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/infra; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-networking.nix
+++ b/nix/.stack.nix/cardano-sl-networking.nix
@@ -210,8 +210,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/networking; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-util-test.nix
+++ b/nix/.stack.nix/cardano-sl-util-test.nix
@@ -94,8 +94,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/util/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl-util.nix
+++ b/nix/.stack.nix/cardano-sl-util.nix
@@ -148,8 +148,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/util; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-sl.nix
+++ b/nix/.stack.nix/cardano-sl.nix
@@ -244,8 +244,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-sl";
-      rev = "35871b5f912f5dd09be6e0cfa89e372046d65bbc";
-      sha256 = "1pk1ss3gzs4lvs9g0fi7xhnz18alcv97s7i1cnysk3v7zimwzlis";
+      rev = "c9c5f6103cbfcdfd6cecf19de5d570785a548cfd";
+      sha256 = "0gynd9cy5rivd8q7rywjr7c3jnz0yr3jy7pli00nkhgwsig55984";
       });
     postUnpack = "sourceRoot+=/lib; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-transport-tcp.nix
+++ b/nix/.stack.nix/network-transport-tcp.nix
@@ -105,7 +105,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/avieth/network-transport-tcp";
-      rev = "2634e5e32178bb0456d800d133f8664321daa2ef";
-      sha256 = "03shp9prflhgqzw7pymw1pq2q7s1wf46pyjm2csx8646snrhf35i";
+      rev = "46f2942423d9ad3c81040565a9e9d5b9e08ddcc4";
+      sha256 = "1nkj414whns56s7p9znn8qn43zp49q7pc5p0py3hdqcva50fd45d";
       });
     }

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -515,7 +515,21 @@ main = do
         -- Thread registry is needed by ChainDB and by the network protocols.
         -- I assume it's supposed to be shared?
         ResourceRegistry.withRegistry $ \rr -> do
-          let protocolVersion = Cardano.ProtocolVersion 0 0 0
+          let -- The "protocol" version means the "blockchain" version, relevant
+              -- to the update system. This is the initial version for updates.
+              -- It is _not_ a part of the blockchain genesis, but it
+              -- nevertheless must be configured properly or update proposals
+              -- may be accepted on one node and not on another. We pull it
+              -- from the cardano-sl configuration.
+              cslBlockVersion = CSL.lastKnownBlockVersion (CSL.ccUpdate yamlConfig)
+              major = CSL.bvMajor cslBlockVersion
+              minor = CSL.bvMinor cslBlockVersion
+              alt   = CSL.bvAlt   cslBlockVersion
+              protocolVersion = Cardano.ProtocolVersion
+                { Cardano.pvMajor = major
+                , Cardano.pvMinor = minor
+                , Cardano.pvAlt   = alt
+                }
               softwareVersion = Cardano.SoftwareVersion
                 (Cardano.ApplicationName (fromString "cardano-byron-proxy")) 2
               protocolInfo = protocolInfoByron

--- a/stack.yaml
+++ b/stack.yaml
@@ -100,7 +100,7 @@ extra-deps:
     commit: 018a50b9042c2115c3ec9c9fd5ca5f28737dd29c
 
   - git: https://github.com/avieth/network-transport-tcp
-    commit: 2634e5e32178bb0456d800d133f8664321daa2ef
+    commit: 46f2942423d9ad3c81040565a9e9d5b9e08ddcc4
 
   - git: https://github.com/avieth/network-transport-inmemory
     commit: 5d8ff2b07b9df35cf61329a3d975e2c8cf95c12a

--- a/stack.yaml
+++ b/stack.yaml
@@ -68,7 +68,7 @@ extra-deps:
 
   # The parts of cardano-sl that are needed for the byron proxy.
   - git: https://github.com/input-output-hk/cardano-sl
-    commit: 35871b5f912f5dd09be6e0cfa89e372046d65bbc
+    commit: c9c5f6103cbfcdfd6cecf19de5d570785a548cfd
     subdirs:
       - lib
       - binary


### PR DESCRIPTION
1. @avieth's fix for block version configuration
1. ￼`network-transport-tcp` bump for the input-output-hk/cardano-node#296 fix
1. `cardano-sl` bump for the same