### PR TITLE
Update ouroboros-network dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -81,49 +81,49 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+  tag: 0476dce67251a324432f3351e726646ac583597a
   subdir: typed-protocols-cbor
 
 --

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -29,8 +29,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "5941c192b64f39d1ab276e0a747a0e47fb52cef8";
-      sha256 = "1yjmyq8r5rgkr54cpnnwncccq6qyfyjfd7glqnr2zc3vh0i2zfah";
+      rev = "0476dce67251a324432f3351e726646ac583597a";
+      sha256 = "19d650sb104pxi7ls0pacpc9d1mhmc6hk3byg7vk11iiy2bxsl8z";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -65,8 +65,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "5941c192b64f39d1ab276e0a747a0e47fb52cef8";
-      sha256 = "1yjmyq8r5rgkr54cpnnwncccq6qyfyjfd7glqnr2zc3vh0i2zfah";
+      rev = "0476dce67251a324432f3351e726646ac583597a";
+      sha256 = "19d650sb104pxi7ls0pacpc9d1mhmc6hk3byg7vk11iiy2bxsl8z";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -42,6 +42,7 @@
           (hsPkgs.filepath)
           (hsPkgs.fingertree)
           (hsPkgs.formatting)
+          (hsPkgs.hashable)
           (hsPkgs.memory)
           (hsPkgs.mmorph)
           (hsPkgs.mtl)
@@ -112,6 +113,7 @@
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.io-sim-classes)
             (hsPkgs.io-sim)
+            (hsPkgs.binary-search)
             (hsPkgs.cborg)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
@@ -181,8 +183,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "5941c192b64f39d1ab276e0a747a0e47fb52cef8";
-      sha256 = "1yjmyq8r5rgkr54cpnnwncccq6qyfyjfd7glqnr2zc3vh0i2zfah";
+      rev = "0476dce67251a324432f3351e726646ac583597a";
+      sha256 = "19d650sb104pxi7ls0pacpc9d1mhmc6hk3byg7vk11iiy2bxsl8z";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -23,11 +23,11 @@
           (hsPkgs.typed-protocols-cbor)
           (hsPkgs.io-sim-classes)
           (hsPkgs.contra-tracer)
-          (hsPkgs.cardano-prelude)
           (hsPkgs.async)
           (hsPkgs.binary)
           (hsPkgs.bytestring)
           (hsPkgs.cardano-binary)
+          (hsPkgs.cardano-prelude)
           (hsPkgs.cborg)
           (hsPkgs.containers)
           (hsPkgs.dns)
@@ -133,8 +133,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "5941c192b64f39d1ab276e0a747a0e47fb52cef8";
-      sha256 = "1yjmyq8r5rgkr54cpnnwncccq6qyfyjfd7glqnr2zc3vh0i2zfah";
+      rev = "0476dce67251a324432f3351e726646ac583597a";
+      sha256 = "19d650sb104pxi7ls0pacpc9d1mhmc6hk3byg7vk11iiy2bxsl8z";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-cbor.nix
+++ b/nix/.stack.nix/typed-protocols-cbor.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "5941c192b64f39d1ab276e0a747a0e47fb52cef8";
-      sha256 = "1yjmyq8r5rgkr54cpnnwncccq6qyfyjfd7glqnr2zc3vh0i2zfah";
+      rev = "0476dce67251a324432f3351e726646ac583597a";
+      sha256 = "19d650sb104pxi7ls0pacpc9d1mhmc6hk3byg7vk11iiy2bxsl8z";
       });
     postUnpack = "sourceRoot+=/typed-protocols-cbor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -43,8 +43,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "5941c192b64f39d1ab276e0a747a0e47fb52cef8";
-      sha256 = "1yjmyq8r5rgkr54cpnnwncccq6qyfyjfd7glqnr2zc3vh0i2zfah";
+      rev = "0476dce67251a324432f3351e726646ac583597a";
+      sha256 = "19d650sb104pxi7ls0pacpc9d1mhmc6hk3byg7vk11iiy2bxsl8z";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/src/exec/DB.hs
+++ b/src/exec/DB.hs
@@ -8,39 +8,32 @@ module DB
   ) where
 
 import           Control.Exception                         (bracket)
-import           Control.Tracer                            (Tracer, nullTracer)
+import           Control.Tracer                            (Tracer)
 import           Data.Time.Clock                           (secondsToDiffTime)
 import qualified System.Directory                          (createDirectoryIfMissing)
-import           System.FilePath                           ((</>))
 
 import qualified Cardano.Chain.Slotting                    as Cardano (EpochSlots (..))
 
-import           Ouroboros.Byron.Proxy.Block               (ByronBlock, isEBB)
+import           Ouroboros.Byron.Proxy.Block               (ByronBlock)
 import qualified Ouroboros.Byron.Proxy.Index.ChainDB       as Index (trackChainDB)
 import qualified Ouroboros.Byron.Proxy.Index.Sqlite        as Sqlite
 import           Ouroboros.Byron.Proxy.Index.Types         (Index)
 import           Ouroboros.Consensus.Block                 (BlockProtocol,
                                                             GetHeader (Header))
-import qualified Ouroboros.Consensus.Ledger.Byron          as Byron
+import           Ouroboros.Consensus.BlockchainTime        (BlockchainTime,
+                                                            SlotLength)
 import           Ouroboros.Consensus.Ledger.Byron.Config   (pbftEpochSlots)
 import           Ouroboros.Consensus.Ledger.Extended       (ExtLedgerState)
+import           Ouroboros.Consensus.Node                  (initChainDB)
 import           Ouroboros.Consensus.Protocol              (NodeConfig,
                                                             pbftExtConfig)
-import           Ouroboros.Consensus.Protocol.Abstract     (protocolSecurityParam)
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry
 import           Ouroboros.Storage.ChainDB.API             (ChainDB)
 import qualified Ouroboros.Storage.ChainDB.API             as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Impl            as ChainDB
 import           Ouroboros.Storage.ChainDB.Impl.Args       (ChainDbArgs (..))
-import           Ouroboros.Storage.Common                  (EpochSize (..))
-import           Ouroboros.Storage.EpochInfo.Impl          (newEpochInfo)
-import           Ouroboros.Storage.FS.API.Types            (MountPoint (..))
-import           Ouroboros.Storage.FS.IO                   (ioHasFS)
-import           Ouroboros.Storage.ImmutableDB.Types       (ValidationPolicy (..))
 import           Ouroboros.Storage.LedgerDB.DiskPolicy     (DiskPolicy (..))
-import           Ouroboros.Storage.LedgerDB.InMemory       (ledgerDbDefaultParams)
-import qualified Ouroboros.Storage.Util.ErrorHandling      as EH
 
 data DBConfig = DBConfig
   { dbFilePath    :: !FilePath
@@ -58,21 +51,41 @@ withDB
   -> Tracer IO (ChainDB.TraceEvent ByronBlock)
   -> Tracer IO Sqlite.TraceEvent
   -> ResourceRegistry IO
+  -> BlockchainTime IO
   -> NodeConfig (BlockProtocol ByronBlock)
   -> ExtLedgerState ByronBlock
+  -> SlotLength
   -> (Index IO (Header ByronBlock) -> ChainDB IO ByronBlock -> IO t)
   -> IO t
-withDB dbOptions dbTracer indexTracer rr nodeConfig extLedgerState k = do
+withDB dbOptions dbTracer indexTracer rr btime nodeConfig extLedgerState slotDuration k = do
   -- The ChainDB/Storage layer will not create a directory for us, we have
   -- to ensure it exists.
   System.Directory.createDirectoryIfMissing True (dbFilePath dbOptions)
-  let epochSlots :: Cardano.EpochSlots
-      epochSlots = pbftEpochSlots $ pbftExtConfig nodeConfig
-      epochSize = EpochSize $
-        fromIntegral (Cardano.unEpochSlots epochSlots)
-  epochInfo <- newEpochInfo (const (pure epochSize))
-  let fp = dbFilePath dbOptions
-      -- Don't use the default 'diskPolicy', because that is meant for core
+
+  bracket openChainDB ChainDB.closeDB $ \cdb ->
+    Sqlite.withIndexAuto epochSlots indexTracer (indexFilePath dbOptions) $ \idx -> do
+      _ <- ResourceRegistry.forkLinkedThread rr $ Index.trackChainDB rr idx cdb
+      k idx cdb
+
+  where
+
+  epochSlots :: Cardano.EpochSlots
+  epochSlots = pbftEpochSlots $ pbftExtConfig nodeConfig
+
+  openChainDB :: IO (ChainDB IO ByronBlock)
+  openChainDB = initChainDB
+    dbTracer
+    rr
+    btime
+    (dbFilePath dbOptions)
+    nodeConfig
+    extLedgerState
+    slotDuration
+    customiseArgs
+
+  customiseArgs :: ChainDbArgs IO ByronBlock -> ChainDbArgs IO ByronBlock
+  customiseArgs args = args
+    { -- Don't use the default 'diskPolicy', because that is meant for core
       -- nodes which update the ledger at most once (with one block) per slot
       -- duration while we're updating the ledger with as many blocks as we
       -- can download per slot duration.
@@ -84,52 +97,11 @@ withDB dbOptions dbTracer indexTracer rr nodeConfig extLedgerState k = do
       -- snapshot have to be replayed against it which requires reading those
       -- blocks and executing the ledger rules, which significantly slows down
       -- startup.
-      ledgerDiskPolicy = DiskPolicy
+      cdbDiskPolicy = DiskPolicy
         { onDiskNumSnapshots  = 2
           -- Take a snapshot every 20s
         , onDiskWriteInterval = return $ secondsToDiffTime 20
         }
-      chainDBArgs :: ChainDbArgs IO ByronBlock
-      chainDBArgs = ChainDB.ChainDbArgs
-        { cdbDecodeHash = Byron.decodeByronHeaderHash
-        , cdbEncodeHash = Byron.encodeByronHeaderHash
-        , cdbHashInfo   = Byron.byronHashInfo
-
-        , cdbDecodeBlock = Byron.decodeByronBlock epochSlots
-        , cdbEncodeBlock = Byron.encodeByronBlockWithInfo
-
-        , cdbDecodeLedger = Byron.decodeByronLedgerState
-        , cdbEncodeLedger = Byron.encodeByronLedgerState
-
-        , cdbDecodeChainState = Byron.decodeByronChainState
-        , cdbEncodeChainState = Byron.encodeByronChainState
-
-        , cdbErrImmDb = EH.exceptions
-        , cdbErrVolDb = EH.exceptions
-        , cdbErrVolDbSTM = EH.throwSTM
-
-        , cdbHasFSImmDb = ioHasFS $ MountPoint (fp </> "immutable")
-        , cdbHasFSVolDb = ioHasFS $ MountPoint (fp </> "volatile")
-        , cdbHasFSLgrDB = ioHasFS $ MountPoint (fp </> "ledger")
-
-        , cdbValidation = ValidateMostRecentEpoch
-        , cdbBlocksPerFile = 21600 -- ?
-        , cdbParamsLgrDB = ledgerDbDefaultParams (protocolSecurityParam nodeConfig)
-        , cdbDiskPolicy = ledgerDiskPolicy
-
-        , cdbNodeConfig = nodeConfig
-        , cdbEpochInfo = epochInfo
-        , cdbIsEBB = isEBB
-        , cdbGenesis = pure extLedgerState
-
-        , cdbTracer = dbTracer
-        , cdbTraceLedger = nullTracer
-        , cdbRegistry = rr
-        , cdbGcDelay = secondsToDiffTime 20
-        }
-  bracket (ChainDB.openDB chainDBArgs) ChainDB.closeDB $ \cdb ->
-    Sqlite.withIndexAuto epochSlots indexTracer (indexFilePath dbOptions) $ \idx -> do
-      -- TBD do we need withRegistry in there or not?
-      -- _ <- ResourceRegistry.forkLinkedThread rr $ ResourceRegistry.withRegistry $ \rr' -> Index.trackChainDB rr' idx cdb
-      _ <- ResourceRegistry.forkLinkedThread rr $ Index.trackChainDB rr idx cdb
-      k idx cdb
+    , cdbBlocksPerFile = 21600 -- ?
+    , cdbGcDelay = secondsToDiffTime 20
+    }

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -10,7 +10,7 @@
 
 {-# LANGUAGE TypeFamilies #-}
 
-import Control.Concurrent.Async (concurrently, link, wait, withAsync)
+import Control.Concurrent.Async (concurrently, link, withAsync)
 import Control.Exception (IOException, throwIO)
 import Control.Monad (mapM, void)
 import Control.Monad.Trans.Except (runExceptT)
@@ -23,6 +23,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy.Builder as Text
 import Data.Time (DiffTime)
+import Data.Void (Void)
 import qualified Network.Socket as Network
 import qualified Options.Applicative as Opt
 import System.FilePath ((</>), takeDirectory)
@@ -83,9 +84,7 @@ import Ouroboros.Consensus.Node.ErrorPolicy (consensusErrorPolicy)
 import Ouroboros.Consensus.Node.ProtocolInfo.Abstract (ProtocolInfo (..))
 import Ouroboros.Consensus.Node.ProtocolInfo.Byron (PBftSignatureThreshold (..),
            protocolInfoByron)
-import Ouroboros.Network.NodeToNode (IPSubscriptionTarget (..), LocalAddresses (..),
-           ErrorPolicies (..), ErrorPolicy (..), NodeToNodeVersion, withServer,
-           ipSubscriptionWorker, newPeerStatesVar)
+import Ouroboros.Network.NodeToNode
 import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry (withRegistry)
 import Ouroboros.Network.Block (BlockNo (..), Point (..))
@@ -93,8 +92,7 @@ import Ouroboros.Network.ErrorPolicy (WithAddr (..), ErrorPolicyTrace (..))
 import Ouroboros.Network.Point (WithOrigin (..))
 import Ouroboros.Network.ErrorPolicy (SuspendDecision (..))
 import Ouroboros.Network.BlockFetch.Client (BlockFetchProtocolFailure)
-import Ouroboros.Network.Protocol.Handshake.Type (HandshakeClientProtocolError, acceptEq)
-import Ouroboros.Network.Protocol.Handshake.Version (DictVersion (..))
+import Ouroboros.Network.Protocol.Handshake.Type (HandshakeClientProtocolError)
 import qualified Ouroboros.Network.TxSubmission.Inbound as TxInbound
 import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
 import Ouroboros.Network.Server.ConnectionTable (ConnectionTable)
@@ -326,28 +324,25 @@ cliParserInfo = Opt.info cliParser infoMod
     <> Opt.fullDesc
 
 runShelleyServer
-  :: ( )
-  => Tracer IO (WithAddr Network.SockAddr ErrorPolicyTrace)
+  :: Tracer IO (WithAddr Network.SockAddr ErrorPolicyTrace)
   -> Address
   -> ResourceRegistry IO
   -> ConnectionTable IO Network.SockAddr
   -> Shelley.ResponderVersions
-  -> IO ()
-runShelleyServer tracer addr _ ctable rversions = do
+  -> IO Void
+runShelleyServer tracer addr _ _ rversions = do
   addrInfo <- resolveAddress addr
-  peerStatesVar <- newPeerStatesVar
+  networkState <- newNetworkMutableState
   withServer
-    nullTracer
-    nullTracer
-    tracer
-    ctable
-    peerStatesVar
+    NetworkServerTracers {
+        nstMuxTracer = nullTracer,
+        nstHandshakeTracer = nullTracer,
+        nstErrorPolicyTracer = tracer
+    }
+    networkState
     addrInfo
-    Shelley.mkPeer
-    (\(DictVersion _) -> acceptEq)
     rversions
     errorPolicy
-    wait
   where
     -- TODO: We might need some additional proxy-specific policies
     errorPolicy = networkErrorPolicy <> consensusErrorPolicy
@@ -360,29 +355,31 @@ runShelleyClient
   -> ResourceRegistry IO
   -> ConnectionTable IO Network.SockAddr
   -> Shelley.InitiatorVersions
-  -> IO ()
-runShelleyClient tracer producerAddrs _ ctable iversions = do
+  -> IO Void
+runShelleyClient tracer producerAddrs _ _ iversions = do
   -- Expect AddrInfo, convert to SockAddr, then pass to ipSubscriptionWorker
   sockAddrs <- mapM resolveAddress producerAddrs
-  peerStatesVar <- newPeerStatesVar -- TODO: Ideally should share state with runShelleyServer
+  networkState <- newNetworkMutableState -- TODO: Ideally should share state with runShelleyServer
   ipSubscriptionWorker
-    nullTracer
-    nullTracer
-    nullTracer
-    tracer
-    Shelley.mkPeer
-    ctable
-    peerStatesVar
-    (LocalAddresses
-     (Just (Network.SockAddrInet 0 0))
-     (Just (Network.SockAddrInet6 0 0 (0, 0, 0, 1) 0))
-     Nothing)
-    (const Nothing)
-    errorPolicy
-    (IPSubscriptionTarget {
-         ispIps     = fmap Network.addrAddress sockAddrs
-       , ispValency = length sockAddrs
+    NetworkIPSubscriptionTracers {
+        nistMuxTracer = nullTracer,
+        nistHandshakeTracer = nullTracer,
+        nistErrorPolicyTracer = tracer,
+        nistSubscriptionTracer = nullTracer
+    }
+    networkState
+    SubscriptionParams {
+      spLocalAddresses = (LocalAddresses
+        (Just (Network.SockAddrInet 0 0))
+        (Just (Network.SockAddrInet6 0 0 (0, 0, 0, 1) 0))
+        Nothing),
+      spConnectionAttemptDelay = const Nothing,
+      spErrorPolicies = errorPolicy,
+      spSubscriptionTarget = (IPSubscriptionTarget {
+          ispIps     = fmap Network.addrAddress sockAddrs
+        , ispValency = length sockAddrs
        })
+    }
     iversions
   where
     -- TODO: We might need some additional proxy-specific policies

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -662,7 +662,7 @@ main = do
               slotDuration = SlotLength (fromRational (toRational slotMs / 1000))
               systemStart = SystemStart (Cardano.gdStartTime (Cardano.configGenesisData newGenesisConfig))
           btime <- realBlockchainTime rr slotDuration systemStart
-          withDB dbc dbTracer indexTracer rr nodeConfig extLedgerState $ \idx cdb -> do
+          withDB dbc dbTracer indexTracer rr btime nodeConfig extLedgerState slotDuration $ \idx cdb -> do
             traceWith (Logging.convertTrace' trace) ("", Monitoring.Info, fromString "Database opened")
             let shelleyClientTracer = contramap (\it -> ("shelley.client", defineSeverity (wiaEvent it), fromString (show it))) (Logging.convertTrace' trace)
                 shelleyServerTracer = contramap (\it -> ("shelley.server", defineSeverity (wiaEvent it), fromString (show it))) (Logging.convertTrace' trace)

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -73,8 +73,8 @@ withShelley rr cdb conf state blockchainTime k = do
   k kernel ctable (initiatorNetworkApplication <$> vs) (responderNetworkApplication <$> vs)
 
 versions
-  :: NodeConfig (BlockProtocol ByronBlock) -> NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ()
-  -> Versions NodeToNodeVersion DictVersion (NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ())
+  :: NodeConfig (BlockProtocol ByronBlock) -> NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ()
+  -> Versions NodeToNodeVersion DictVersion (NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ())
 versions conf = simpleSingletonVersions NodeToNodeV_1 (NodeToNodeVersionData (nodeNetworkMagic (Proxy @ByronBlock) conf)) (DictVersion nodeToNodeCodecCBORTerm)
 
 mkParams

--- a/src/exec/Shelley.hs
+++ b/src/exec/Shelley.hs
@@ -7,20 +7,18 @@ module Shelley where
 
 import qualified Data.ByteString.Lazy as Lazy
 import Data.Void (Void)
-import Network.Socket (SockAddr)
 
 -- ToCBOR/FromCBOR UTxOValidationError, for local tx submission codec.
 import Cardano.Chain.UTxO.Validation ()
 import Crypto.Random (drgNew)
 import qualified Network.Socket as Socket
 
-import Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF(..), Proxy(..))
+import Cardano.Prelude (Proxy(..))
 
 import Ouroboros.Byron.Proxy.Block (ByronBlock)
 import Ouroboros.Consensus.Block (BlockProtocol)
 import Ouroboros.Consensus.Protocol (NodeConfig, NodeState)
 import Ouroboros.Consensus.Mempool.Impl (MempoolCapacity (..))
-import Ouroboros.Consensus.Util.Condense (Condense (..))
 import Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import Ouroboros.Storage.ChainDB.API (ChainDB)
 
@@ -37,19 +35,9 @@ import Ouroboros.Consensus.Node.Tracers (nullTracers)
 import Ouroboros.Consensus.Node.Run.Abstract (nodeBlockFetchSize, nodeBlockMatchesHeader)
 import Ouroboros.Consensus.NodeNetwork
 
-newtype Peer = Peer { getPeer :: (SockAddr, SockAddr) }
-  deriving (Eq, Ord, Show)
-  deriving NoUnexpectedThunks via OnlyCheckIsWHNF "Peer" Peer
+type InitiatorVersions = Versions NodeToNodeVersion DictVersion (OuroborosApplication 'InitiatorApp ConnectionId NodeToNodeProtocols IO Lazy.ByteString () Void)
 
-instance Condense Peer where
-  condense = show
-
-mkPeer :: SockAddr -> SockAddr -> Peer
-mkPeer a b = Peer (a, b)
-
-type InitiatorVersions = Versions NodeToNodeVersion DictVersion (OuroborosApplication 'InitiatorApp Peer NodeToNodeProtocols IO Lazy.ByteString () Void)
-
-type ResponderVersions = Versions NodeToNodeVersion DictVersion (OuroborosApplication 'ResponderApp Peer NodeToNodeProtocols IO Lazy.ByteString Void ())
+type ResponderVersions = Versions NodeToNodeVersion DictVersion (OuroborosApplication 'ResponderApp ConnectionId NodeToNodeProtocols IO Lazy.ByteString Void ())
 
 -- Must have `ByronGiven` because of the constraints on `nodeKernel`
 withShelley
@@ -58,7 +46,7 @@ withShelley
   -> NodeConfig (BlockProtocol ByronBlock)
   -> NodeState (BlockProtocol ByronBlock)
   -> BlockchainTime IO
-  -> (NodeKernel IO Peer ByronBlock -> ConnectionTable IO Socket.SockAddr -> InitiatorVersions -> ResponderVersions -> IO t)
+  -> (NodeKernel IO ConnectionId ByronBlock -> ConnectionTable IO Socket.SockAddr -> InitiatorVersions -> ResponderVersions -> IO t)
   -> IO t
 withShelley rr cdb conf state blockchainTime k = do
   ctable <- newConnectionTable
@@ -73,8 +61,8 @@ withShelley rr cdb conf state blockchainTime k = do
   k kernel ctable (initiatorNetworkApplication <$> vs) (responderNetworkApplication <$> vs)
 
 versions
-  :: NodeConfig (BlockProtocol ByronBlock) -> NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ()
-  -> Versions NodeToNodeVersion DictVersion (NetworkApplication IO Peer Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ())
+  :: NodeConfig (BlockProtocol ByronBlock) -> NetworkApplication IO ConnectionId Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ()
+  -> Versions NodeToNodeVersion DictVersion (NetworkApplication IO ConnectionId Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString Lazy.ByteString ())
 versions conf = simpleSingletonVersions NodeToNodeV_1 (NodeToNodeVersionData (nodeNetworkMagic (Proxy @ByronBlock) conf)) (DictVersion nodeToNodeCodecCBORTerm)
 
 mkParams
@@ -83,7 +71,7 @@ mkParams
   -> NodeConfig (BlockProtocol ByronBlock)
   -> NodeState (BlockProtocol ByronBlock)
   -> BlockchainTime IO
-  -> NodeArgs IO Peer ByronBlock
+  -> NodeArgs IO ConnectionId ByronBlock
 mkParams rr cdb nconf nstate blockchainTime = NodeArgs
   { tracers = nullTracers
   , registry = rr

--- a/src/lib/Ouroboros/Byron/Proxy/Main.hs
+++ b/src/lib/Ouroboros/Byron/Proxy/Main.hs
@@ -601,7 +601,7 @@ bbsGetHashesRange rr idx db onErr mLimit from to = do
     case outcome of
       Left (ChainDB.MissingBlock _point)      -> onErr "FIXME put error message"
       Left (ChainDB.ForkTooOld   _streamFrom) -> onErr "FIXME put error message"
-      Right iterator                          -> pure iterator
+      Right iterator                          -> pure $ ChainDB.deserialiseIterator iterator
 
   releaseIterator = ChainDB.iteratorClose
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 5941c192b64f39d1ab276e0a747a0e47fb52cef8
+    commit: 0476dce67251a324432f3351e726646ac583597a
     subdirs:
       - ouroboros-consensus
       - ouroboros-network


### PR DESCRIPTION
We switch to `initChainDB` instead of manually constructing the `ChainDbArgs`, it is easier and more future-proof.

@karknu made the network-related changes.