### PR TITLE
Always add the genesis block and consider it a possible checkpoint

### DIFF
--- a/cardano-byron-proxy.cabal
+++ b/cardano-byron-proxy.cabal
@@ -145,8 +145,6 @@ executable cddl-test
                        cardano-crypto-wrapper,
                        cardano-ledger,
                        cborg,
-                       contra-tracer,
-                       filepath,
                        ouroboros-consensus,
                        process-extras
   ghc-options:         -threaded

--- a/nix/.stack.nix/cardano-byron-proxy.nix
+++ b/nix/.stack.nix/cardano-byron-proxy.nix
@@ -113,8 +113,6 @@
             (hsPkgs.cardano-crypto-wrapper)
             (hsPkgs.cardano-ledger)
             (hsPkgs.cborg)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.filepath)
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.process-extras)
             ];


### PR DESCRIPTION
Fixes #87.

Since ouroboros-network#1450, a dummy genesis EBB is automatically added to an empty ChainDB on startup. See ouroboros-network#1447 for why we have to do this.

The byron-proxy does a similar thing: when the ChainDB is empty, it adds the *real* (from the mainnet) genesis EBB to ChainDB. This genesis EBB is not the same as the dummy genesis EBB that ouroboros-consensus added to the ChainDB.

When the byron-proxy wants to sync from old nodes, it sends some checkpoints from the current chain to find an intersection. When the current chain only contains the dummy genesis EBB, only the checkpoint corresponding to that dummy genesis EBB is sent. As the old nodes don't have this EBB, no intersection is found.

The new approach is to *always* add the real genesis EBB to the ChainDB. When it already contains the real genesis EBB (i.e., when the database is non-empty), this will be basically be a no-op anyway. Furthermore, when picking checkpoints from the current chain to find an intersection, treat the `GenesisHash`, which will be a potential checkpoint corresponding to the empty chain when near genesis, as the real genesis EBB.