### PR TITLE
Update to cardano-sl version with OBFT EBB epoch 0 fix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -270,113 +270,113 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: lib
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: util
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: util/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: infra/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: core
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: core/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: chain
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: chain/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: db/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl
-  tag: a4c7991852017b8a24ad197050600d593a2e07cb
-  --sha256: 0m0nrxfzgp9ryjnfjrl7hwqb27d3cpdng927fx6jvxca3c749vdm
+  tag: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
+  --sha256: 1n6as8hhdkacm7ivir8138x2jh6ym473lpqzx6zyy2b6nw4j27mw
   subdir: networking
 
 source-repository-package

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -495,9 +495,12 @@ runByron tracer byronOptions genesisConfig blockConfig updateConfig nodeConfig e
                 networkConfig'
                 64 -- Batch size.
                 trace
-        genesisBlock = CSL.genesisBlock0 (CSL.configProtocolMagic genesisConfig)
-                                         (CSL.configGenesisHash genesisConfig)
-                                         (CSL.genesisLeaders genesisConfig)
+        genesisBlock =
+          CSL.genesisBlock0
+            (CSL.consensusEraBVD (CSL.configBlockVersionData genesisConfig))
+            (CSL.configProtocolMagic genesisConfig)
+            (CSL.configGenesisHash genesisConfig)
+            (CSL.genesisLeaders genesisConfig)
     -- *MUST* launch static config monitoring thread, otherwise nodes
     -- configured with static routes *will not update their peers lists*.
     -- It would be much better if intNetworkConfigOpts set up the static

--- a/stack.yaml
+++ b/stack.yaml
@@ -88,7 +88,7 @@ extra-deps:
 
   # The parts of cardano-sl that are needed for the byron proxy.
   - git: https://github.com/input-output-hk/cardano-sl
-    commit: a4c7991852017b8a24ad197050600d593a2e07cb
+    commit: ff10fcb2c6706175df57bb8b9c8008231a8fbe18
     subdirs:
       - lib
       - binary


### PR DESCRIPTION
When we start a chain from a genesis in the OBFT era, rather than the Original era, the epoch zero EBB must still exist, even though all other epoch EBBs do not exist.

That EBB ought to have an empty slot leader schedule, otherwise we cannot have new non-legcay nodes create the same EBB, since new nodes do not implement the logic for Original era leader schedules. This does not affects any existing chain, since existing chains all start in the
Original era and go through a hard fork to enter the OBFT era. This change only affects new test/dev chains that start in the OBFT era. This is needed to test mixed clusters of old/new nodes in a convenient way, that all start from genesis in the OBFT era.

This patch updates to a version of cardano-sl that has the necessary changes to do this. The proxy also has to put the initial EBB into its local chain database to be able to talk to old and new nodes.